### PR TITLE
feat: 全新機能のフロントエンドUI実装

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -184,3 +184,12 @@ def register_blueprints(app: Flask):
         print("✅ 3者会話ルートを登録しました (/api/three-way/*)")
     except ImportError as e:
         print(f"⚠️ 3者会話ルートは利用できません: {e}")
+
+    # ゲーミフィケーション・ダッシュボード画面
+    try:
+        from routes.gamification_page_routes import gamification_page_bp
+
+        app.register_blueprint(gamification_page_bp)
+        print("✅ ゲーミフィケーション画面を登録しました (/gamification)")
+    except ImportError as e:
+        print(f"⚠️ ゲーミフィケーション画面は利用できません: {e}")

--- a/routes/gamification_page_routes.py
+++ b/routes/gamification_page_routes.py
@@ -1,0 +1,21 @@
+"""
+ゲーミフィケーション・ダッシュボード画面
+"""
+
+from __future__ import annotations
+
+from flask import Blueprint, render_template
+
+from config.feature_flags import get_feature_flags
+
+gamification_page_bp = Blueprint("gamification_page", __name__)
+
+
+@gamification_page_bp.route("/gamification")
+def gamification_dashboard():
+    """学習ダッシュボード（XP・クエスト・分析・エクスポート）"""
+    feature_flags = get_feature_flags()
+    return render_template(
+        "gamification.html",
+        feature_flags=feature_flags.to_dict(),
+    )

--- a/static/js/chat-enhancements.js
+++ b/static/js/chat-enhancements.js
@@ -1,0 +1,134 @@
+/**
+ * 雑談チャット拡張: realtime_feedback、モデレーション、要約カード
+ */
+(function () {
+    function esc(s) {
+        return String(s ?? "")
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+    }
+
+    function ensureHosts() {
+        const cc = document.getElementById("chat-container");
+        if (!cc) return;
+        const anchor = document.querySelector("#chat-container .chat-area") || cc;
+        let fb = document.getElementById("realtime-feedback-host");
+        if (!fb) {
+            fb = document.createElement("div");
+            fb.id = "realtime-feedback-host";
+            fb.className = "content-section";
+            fb.style.marginTop = "1rem";
+            if (anchor.nextSibling) {
+                cc.insertBefore(fb, anchor.nextSibling);
+            } else {
+                cc.appendChild(fb);
+            }
+        }
+        let sum = document.getElementById("summary-card-host");
+        if (!sum) {
+            sum = document.createElement("div");
+            sum.id = "summary-card-host";
+            sum.className = "content-section";
+            sum.style.marginTop = "1rem";
+            cc.appendChild(sum);
+        }
+    }
+
+    function showRealtimeFeedback(fb) {
+        if (!fb || !fb.has_feedback) return;
+        ensureHosts();
+        const host = document.getElementById("realtime-feedback-host");
+        if (!host) return;
+        host.style.display = "block";
+        host.innerHTML = `
+      <div class="card-shadow">
+        <h3><i class="fas fa-lightbulb"></i> リアルタイムフィードバック</h3>
+        <p>${esc(fb.suggestion || "")}</p>
+        <p id="summary-trigger-wrap"><button type="button" class="secondary-button" id="btn-open-summary"><i class="fas fa-align-left"></i> 要約を見る</button></p>
+      </div>`;
+        document.getElementById("btn-open-summary")?.addEventListener("click", () => {
+            loadSummary();
+        });
+    }
+
+    function scrapeHistory() {
+        const msgs = [];
+        document.querySelectorAll("#chat-messages .message").forEach((el) => {
+            const t = (el.textContent || "").trim();
+            if (el.classList.contains("user-message")) {
+                msgs.push({ role: "user", content: t.replace(/^あなた:\s*/, "") });
+            } else if (el.classList.contains("bot-message")) {
+                msgs.push({ role: "assistant", content: t.replace(/^相手:\s*/, "") });
+            }
+        });
+        return msgs;
+    }
+
+    async function loadSummary() {
+        ensureHosts();
+        const host = document.getElementById("summary-card-host");
+        if (!host) return;
+        host.style.display = "block";
+        host.innerHTML = "<p>要約を取得しています…</p>";
+        try {
+            const res = await fetch("/api/summary/generate", {
+                method: "POST",
+                credentials: "same-origin",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ history: scrapeHistory(), mode: "chat" }),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "summary failed");
+            const kp = (data.key_points || []).map((x) => `<li>${esc(x)}</li>`).join("");
+            const lp = (data.learning_points || []).map((x) => `<li>${esc(x)}</li>`).join("");
+            host.innerHTML = `
+        <div class="card-shadow">
+          <h3><i class="fas fa-file-alt"></i> 要約</h3>
+          <p>${esc(data.summary || "")}</p>
+          <h4>キーポイント</h4><ul>${kp}</ul>
+          <h4>学習ポイント</h4><ul>${lp}</ul>
+        </div>`;
+        } catch (e) {
+            host.innerHTML = `<p class="error-message" style="display:block;">${esc(e.message)}</p>`;
+        }
+    }
+
+    function showModerationWarning(data) {
+        ensureHosts();
+        const host = document.getElementById("realtime-feedback-host");
+        if (!host) return;
+        host.style.display = "block";
+        const m = data.moderation || {};
+        host.innerHTML = `<div class="error-message" style="display:block;">${esc(
+            m.reason || "不適切な表現が含まれています。"
+        )}</div>`;
+    }
+
+    function patchFetch() {
+        const prev = window.fetch.bind(window);
+        window.fetch = async function (input, init) {
+            const res = await prev(input, init);
+            try {
+                const url = typeof input === "string" ? input : input.url;
+                if (url.includes("/api/chat") && (init || {}).method === "POST") {
+                    const clone = res.clone();
+                    const data = await clone.json();
+                    if (res.status === 400 && data.moderation) {
+                        showModerationWarning(data);
+                    } else if (res.ok && data.realtime_feedback) {
+                        showRealtimeFeedback(data.realtime_feedback);
+                    }
+                }
+            } catch (e) {
+                console.warn("chat-enhancements", e);
+            }
+            return res;
+        };
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+        ensureHosts();
+        patchFetch();
+    });
+})();

--- a/static/js/csrf-manager.js
+++ b/static/js/csrf-manager.js
@@ -23,7 +23,16 @@ class CSRFManager {
                 '/api/conversation_history',
                 '/api/tts',
                 '/api/generate_character_image',
-                '/api/strength_analysis'
+                '/api/strength_analysis',
+                '/api/three-way/join',
+                '/api/three-way/message',
+                '/api/three-way/leave',
+                '/api/quiz/generate',
+                '/api/quiz/answer',
+                '/api/summary/generate',
+                '/api/export/csv',
+                '/api/export/json',
+                '/api/tutorial/complete'
             ]
         };
         

--- a/static/js/gamification-dashboard.js
+++ b/static/js/gamification-dashboard.js
@@ -83,7 +83,7 @@
             .map((row) => {
                 const b = row.badge || row;
                 const earned = b.earned ? "獲得済" : "未獲得";
-                const cls = b.earned ? "feature-card" : "feature-card";
+                const cls = b.earned ? "feature-card" : "feature-card feature-card--locked";
                 return `<div class="${cls}" style="opacity:${b.earned ? 1 : 0.75}">
             <h3>${esc(b.name || b.badge_id)}</h3>
             <p>${esc(earned)}</p>
@@ -179,7 +179,7 @@
     async function initDashboard() {
         const errBox = document.getElementById("dashboard-error");
         try {
-            const [dash, growth, practice, skills, weakness] = await Promise.all([
+            const [dash, growth, practice, skills, weakness] = await Promise.allSettled([
                 fetchJson("/api/gamification/dashboard"),
                 fetchJson("/api/gamification/growth"),
                 fetchJson("/api/analytics/practice-stats"),
@@ -187,11 +187,14 @@
                 fetchJson("/api/analytics/weakness"),
             ]);
 
-            renderXpBars(dash.skill_xp);
-            renderQuests(dash.quests);
-            renderBadges(dash.badges_overview);
-            renderGrowthChart(growth);
-            renderAnalytics(practice, skills, weakness);
+            const v = (r) => r.status === "fulfilled" ? r.value : null;
+            if (v(dash)) {
+                renderXpBars(v(dash).skill_xp);
+                renderQuests(v(dash).quests);
+                renderBadges(v(dash).badges_overview);
+            }
+            if (v(growth)) renderGrowthChart(v(growth));
+            if (v(practice) || v(skills) || v(weakness)) renderAnalytics(v(practice), v(skills), v(weakness));
 
             document.getElementById("btn-export-csv")?.addEventListener("click", () =>
                 downloadExport("/api/export/csv", "conversations.csv", "text/csv").catch((e) =>

--- a/static/js/gamification-dashboard.js
+++ b/static/js/gamification-dashboard.js
@@ -1,0 +1,216 @@
+/**
+ * ゲーミフィケーション・ダッシュボード
+ * /api/gamification/dashboard, /growth, /api/analytics/*, /api/export/*
+ */
+(function () {
+    const AXIS_LABELS = {
+        empathy: "共感",
+        clarity: "明瞭さ",
+        active_listening: "傾聴",
+        adaptability: "適応",
+        positivity: "前向きさ",
+        professionalism: "専門性",
+    };
+
+    function esc(s) {
+        return String(s ?? "")
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;");
+    }
+
+    async function fetchJson(url) {
+        const res = await fetch(url, { credentials: "same-origin" });
+        if (!res.ok) throw new Error(`${url} ${res.status}`);
+        return res.json();
+    }
+
+    function renderXpBars(skillXp) {
+        const el = document.getElementById("xp-bars-container");
+        if (!el || !skillXp || typeof skillXp !== "object") {
+            if (el) el.innerHTML = "<p>データがありません。</p>";
+            return;
+        }
+        const max = Math.max(1, ...Object.values(skillXp).map((v) => Number(v) || 0));
+        el.innerHTML = Object.entries(skillXp)
+            .map(([k, v]) => {
+                const n = Number(v) || 0;
+                const pct = Math.min(100, Math.round((n / max) * 100));
+                const label = AXIS_LABELS[k] || k;
+                return `<div style="margin-bottom:0.75rem;">
+          <div style="display:flex;justify-content:space-between;font-size:0.9rem;">
+            <span>${esc(label)}</span><span>${esc(n)} XP</span>
+          </div>
+          <div style="background:#e5e7eb;border-radius:8px;height:10px;overflow:hidden;">
+            <div style="width:${pct}%;height:100%;background:var(--primary-color,#3b3b6b);"></div>
+          </div>
+        </div>`;
+            })
+            .join("");
+    }
+
+    function renderQuests(questsPayload) {
+        const dailyEl = document.getElementById("quests-daily");
+        const weeklyEl = document.getElementById("quests-weekly");
+        if (!questsPayload || typeof questsPayload !== "object") return;
+        const daily = questsPayload.daily || [];
+        const weekly = questsPayload.weekly || [];
+        const fmt = (list, title) => {
+            if (!list.length) return `<p><strong>${esc(title)}</strong>: なし</p>`;
+            return `<p><strong>${esc(title)}</strong></p><ul>${list
+                .map(
+                    (q) =>
+                        `<li>${esc(q.description || q.title || "")} — ${esc(q.current_value)}/${esc(
+                            q.target_value
+                        )}</li>`
+                )
+                .join("")}</ul>`;
+        };
+        if (dailyEl) dailyEl.innerHTML = fmt(daily, "デイリー");
+        if (weeklyEl) weeklyEl.innerHTML = fmt(weekly, "ウィークリー");
+    }
+
+    function renderBadges(overview) {
+        const grid = document.getElementById("badge-grid");
+        if (!grid) return;
+        const items = (overview && overview.badges) || [];
+        if (!items.length) {
+            grid.innerHTML = "<p>バッジ情報がありません。</p>";
+            return;
+        }
+        grid.innerHTML = items
+            .map((row) => {
+                const b = row.badge || row;
+                const earned = b.earned ? "獲得済" : "未獲得";
+                const cls = b.earned ? "feature-card" : "feature-card";
+                return `<div class="${cls}" style="opacity:${b.earned ? 1 : 0.75}">
+            <h3>${esc(b.name || b.badge_id)}</h3>
+            <p>${esc(earned)}</p>
+          </div>`;
+            })
+            .join("");
+    }
+
+    function renderAnalytics(practice, skills, weakness) {
+        const p = document.getElementById("analytics-practice");
+        const s = document.getElementById("analytics-skills");
+        const w = document.getElementById("analytics-weakness");
+        if (p && practice) {
+            p.innerHTML = `<p>累計時間: ${esc(practice.total_time_minutes)} 分 / セッション数: ${esc(
+                practice.session_count
+            )} / 平均: ${esc(practice.avg_session_minutes)} 分 / 活発な曜日: ${esc(
+                practice.most_active_day
+            )}</p>`;
+        }
+        if (s && skills && typeof skills === "object") {
+            s.innerHTML =
+                "<p><strong>6軸スキル</strong></p><ul>" +
+                Object.entries(skills)
+                    .map(([axis, row]) => {
+                        const r = row || {};
+                        return `<li>${esc(AXIS_LABELS[axis] || axis)}: 現在 ${esc(
+                            r.current
+                        )} / 成長率 ${esc(r.growth_rate)} / ランク ${esc(r.rank)}</li>`;
+                    })
+                    .join("") +
+                "</ul>";
+        }
+        if (w && Array.isArray(weakness)) {
+            w.innerHTML =
+                "<p><strong>改善ポイント</strong></p><ul>" +
+                weakness
+                    .slice(0, 6)
+                    .map(
+                        (x) =>
+                            `<li>${esc(AXIS_LABELS[x.axis] || x.axis)} (score ${esc(x.score)}): ${esc(
+                                x.recommendation
+                            )}</li>`
+                    )
+                    .join("") +
+                "</ul>";
+        }
+    }
+
+    let growthChart;
+
+    function renderGrowthChart(growth) {
+        const canvas = document.getElementById("growth-chart");
+        if (!canvas || !window.Chart || !growth) return;
+        const avg = growth.last_10_average || {};
+        const labels = Object.keys(avg).map((k) => AXIS_LABELS[k] || k);
+        const data = Object.keys(avg).map((k) => Number(avg[k]) || 0);
+        if (growthChart) growthChart.destroy();
+        growthChart = new Chart(canvas.getContext("2d"), {
+            type: "bar",
+            data: {
+                labels,
+                datasets: [
+                    {
+                        label: "直近の平均XP（参考）",
+                        data,
+                        backgroundColor: "rgba(59, 59, 107, 0.6)",
+                    },
+                ],
+            },
+            options: {
+                responsive: true,
+                scales: { y: { beginAtZero: true } },
+            },
+        });
+    }
+
+    async function downloadExport(path, filename) {
+        const res = await fetch(path, {
+            method: "POST",
+            credentials: "same-origin",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ history: [] }),
+        });
+        if (!res.ok) throw new Error("export failed");
+        const blob = await res.blob();
+        const a = document.createElement("a");
+        a.href = URL.createObjectURL(blob);
+        a.download = filename;
+        a.click();
+        URL.revokeObjectURL(a.href);
+    }
+
+    async function initDashboard() {
+        const errBox = document.getElementById("dashboard-error");
+        try {
+            const [dash, growth, practice, skills, weakness] = await Promise.all([
+                fetchJson("/api/gamification/dashboard"),
+                fetchJson("/api/gamification/growth"),
+                fetchJson("/api/analytics/practice-stats"),
+                fetchJson("/api/analytics/skill-progress"),
+                fetchJson("/api/analytics/weakness"),
+            ]);
+
+            renderXpBars(dash.skill_xp);
+            renderQuests(dash.quests);
+            renderBadges(dash.badges_overview);
+            renderGrowthChart(growth);
+            renderAnalytics(practice, skills, weakness);
+
+            document.getElementById("btn-export-csv")?.addEventListener("click", () =>
+                downloadExport("/api/export/csv", "conversations.csv", "text/csv").catch((e) =>
+                    alert(e.message)
+                )
+            );
+            document.getElementById("btn-export-json")?.addEventListener("click", () =>
+                downloadExport("/api/export/json", "conversations.json", "application/json").catch((e) =>
+                    alert(e.message)
+                )
+            );
+        } catch (e) {
+            console.error(e);
+            if (errBox) {
+                errBox.style.display = "block";
+                errBox.textContent = "ダッシュボードの読み込みに失敗しました: " + e.message;
+            }
+        }
+    }
+
+    document.addEventListener("DOMContentLoaded", initDashboard);
+})();

--- a/static/js/three-way.js
+++ b/static/js/three-way.js
@@ -1,0 +1,104 @@
+/**
+ * 3者会話: /api/three-way/join, /message, /leave
+ */
+(function () {
+    let active = false;
+
+    function getRoot() {
+        return document.getElementById("three-way-root");
+    }
+
+    function renderPanel() {
+        const root = getRoot();
+        if (!root) return;
+        root.innerHTML = `
+      <div class="settings-section" style="margin-top:1rem;">
+        <h2><i class="fas fa-users"></i> 会話に参加（3者）</h2>
+        <div class="action-buttons">
+          <button type="button" id="three-way-join" class="primary-button"><i class="fas fa-sign-in-alt"></i> 会話に参加</button>
+          <button type="button" id="three-way-leave" class="secondary-button" style="display:none;"><i class="fas fa-sign-out-alt"></i> 退出</button>
+        </div>
+        <div id="three-way-compose" style="display:none;margin-top:1rem;">
+          <textarea id="three-way-message" class="enhanced-select" style="width:100%;min-height:80px;" placeholder="メッセージを入力"></textarea>
+          <button type="button" id="three-way-send" class="primary-button" style="margin-top:0.5rem;"><i class="fas fa-paper-plane"></i> 送信</button>
+        </div>
+        <p id="three-way-status" class="mode-description"></p>
+      </div>`;
+
+        document.getElementById("three-way-join")?.addEventListener("click", onJoin);
+        document.getElementById("three-way-leave")?.addEventListener("click", onLeave);
+        document.getElementById("three-way-send")?.addEventListener("click", onSend);
+    }
+
+    async function onJoin() {
+        const status = document.getElementById("three-way-status");
+        try {
+            const res = await fetch("/api/three-way/join", {
+                method: "POST",
+                credentials: "same-origin",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({}),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "join failed");
+            active = !!data.joined;
+            if (data.joined) {
+                document.getElementById("three-way-compose").style.display = "block";
+                document.getElementById("three-way-leave").style.display = "inline-flex";
+                document.getElementById("three-way-join").style.display = "none";
+                if (status) status.textContent = "参加中。メッセージを送信できます。";
+            } else {
+                if (status) status.textContent = data.error || "参加できませんでした。";
+            }
+        } catch (e) {
+            if (status) status.textContent = e.message;
+        }
+    }
+
+    async function onSend() {
+        const ta = document.getElementById("three-way-message");
+        const msg = (ta && ta.value) || "";
+        if (!msg.trim()) return;
+        const status = document.getElementById("three-way-status");
+        try {
+            const res = await fetch("/api/three-way/message", {
+                method: "POST",
+                credentials: "same-origin",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ message: msg }),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "send failed");
+            ta.value = "";
+            if (status) status.textContent = "送信しました。次の話者: " + (data.next_speaker || "");
+            if (typeof displayMessage === "function") {
+                displayMessage("あなた: " + msg, "user-message");
+            }
+        } catch (e) {
+            if (status) status.textContent = e.message;
+        }
+    }
+
+    async function onLeave() {
+        const status = document.getElementById("three-way-status");
+        try {
+            const res = await fetch("/api/three-way/leave", {
+                method: "POST",
+                credentials: "same-origin",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({}),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "leave failed");
+            active = false;
+            document.getElementById("three-way-compose").style.display = "none";
+            document.getElementById("three-way-leave").style.display = "none";
+            document.getElementById("three-way-join").style.display = "inline-flex";
+            if (status) status.textContent = "観戦モードに戻りました（mode: " + (data.mode || "watch") + "）";
+        } catch (e) {
+            if (status) status.textContent = e.message;
+        }
+    }
+
+    document.addEventListener("DOMContentLoaded", renderPanel);
+})();

--- a/static/js/tutorial-overlay.js
+++ b/static/js/tutorial-overlay.js
@@ -1,0 +1,94 @@
+/**
+ * チュートリアルオーバーレイ: first-visit, steps, complete
+ */
+(function () {
+    const MODE = "scenario";
+
+    function esc(s) {
+        return String(s ?? "")
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+    }
+
+    function ensureOverlay() {
+        let el = document.getElementById("tutorial-overlay");
+        if (el) return el;
+        el = document.createElement("div");
+        el.id = "tutorial-overlay";
+        el.style.cssText =
+            "display:none;position:fixed;inset:0;background:rgba(0,0,0,0.45);z-index:10000;align-items:center;justify-content:center;padding:1rem;";
+        el.innerHTML = `
+      <div class="modal-content" style="max-width:520px;position:relative;background:#fff;border-radius:12px;padding:1.5rem;">
+        <h3 id="tutorial-step-title"></h3>
+        <p id="tutorial-step-desc"></p>
+        <div class="action-buttons" style="margin-top:1rem;">
+          <button type="button" id="tutorial-next" class="primary-button">次へ</button>
+          <button type="button" id="tutorial-skip" class="secondary-button">スキップ</button>
+        </div>
+      </div>`;
+        document.body.appendChild(el);
+        return el;
+    }
+
+    let steps = [];
+    let idx = 0;
+
+    function showStep() {
+        const overlay = ensureOverlay();
+        const st = steps[idx];
+        if (!st) {
+            overlay.style.display = "none";
+            return;
+        }
+        document.getElementById("tutorial-step-title").textContent = st.title || "";
+        document.getElementById("tutorial-step-desc").textContent = st.description || "";
+        overlay.style.display = "flex";
+    }
+
+    async function completeCurrent() {
+        const st = steps[idx];
+        if (!st) return;
+        await fetch("/api/tutorial/complete", {
+            method: "POST",
+            credentials: "same-origin",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mode: MODE, step: st.step }),
+        });
+    }
+
+    async function init() {
+        try {
+            const fv = await fetch("/api/tutorial/first-visit", { credentials: "same-origin" });
+            const data = await fv.json();
+            if (!data.first_visit) return;
+
+            const res = await fetch(`/api/tutorial/steps?mode=${encodeURIComponent(MODE)}`, {
+                credentials: "same-origin",
+            });
+            steps = await res.json();
+            if (!Array.isArray(steps) || !steps.length) return;
+
+            idx = 0;
+            const overlay = ensureOverlay();
+            showStep();
+
+            document.getElementById("tutorial-next").onclick = async () => {
+                await completeCurrent();
+                idx += 1;
+                if (idx >= steps.length) {
+                    overlay.style.display = "none";
+                    return;
+                }
+                showStep();
+            };
+            document.getElementById("tutorial-skip").onclick = () => {
+                overlay.style.display = "none";
+            };
+        } catch (e) {
+            console.warn("tutorial-overlay", e);
+        }
+    }
+
+    document.addEventListener("DOMContentLoaded", init);
+})();

--- a/static/js/watch-quiz.js
+++ b/static/js/watch-quiz.js
@@ -1,0 +1,137 @@
+/**
+ * 観戦クイズ: /api/watch/next の quiz をモーダル表示、/api/quiz/answer、/api/quiz/summary
+ */
+(function () {
+    let lastQuiz = null;
+
+    function esc(s) {
+        return String(s ?? "")
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+    }
+
+    function ensureModal() {
+        let modal = document.getElementById("watch-quiz-modal");
+        if (modal) return modal;
+        modal = document.createElement("div");
+        modal.id = "watch-quiz-modal";
+        modal.className = "modal";
+        modal.style.display = "none";
+        modal.innerHTML = `
+      <div class="modal-content" style="max-width:480px;">
+        <span class="close" id="watch-quiz-close" style="cursor:pointer">&times;</span>
+        <h3 id="watch-quiz-title">クイズ</h3>
+        <p id="watch-quiz-question"></p>
+        <div id="watch-quiz-choices"></div>
+        <div id="watch-quiz-result" style="margin-top:1rem;"></div>
+      </div>`;
+        document.body.appendChild(modal);
+        document.getElementById("watch-quiz-close").addEventListener("click", () => {
+            modal.style.display = "none";
+        });
+        return modal;
+    }
+
+    function showQuizModal(quiz) {
+        lastQuiz = quiz;
+        const modal = ensureModal();
+        const qEl = document.getElementById("watch-quiz-question");
+        const cEl = document.getElementById("watch-quiz-choices");
+        const rEl = document.getElementById("watch-quiz-result");
+        if (rEl) rEl.innerHTML = "";
+        if (qEl) qEl.textContent = quiz.question || "";
+        if (cEl) {
+            cEl.innerHTML = "";
+            (quiz.choices || []).forEach((label, idx) => {
+                const btn = document.createElement("button");
+                btn.type = "button";
+                btn.className = "secondary-button";
+                btn.style.margin = "0.25rem";
+                btn.textContent = label;
+                btn.addEventListener("click", () => submitAnswer(idx));
+                cEl.appendChild(btn);
+            });
+        }
+        modal.style.display = "block";
+    }
+
+    async function submitAnswer(idx) {
+        const rEl = document.getElementById("watch-quiz-result");
+        try {
+            const res = await fetch("/api/quiz/answer", {
+                method: "POST",
+                credentials: "same-origin",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    user_answer: idx,
+                    quiz: lastQuiz,
+                    context: [],
+                }),
+            });
+            const data = await res.json();
+            if (!res.ok) throw new Error(data.error || "answer failed");
+            if (rEl) {
+                rEl.innerHTML = `<p><strong>${data.is_correct ? "正解！" : "不正解"}</strong></p><p>${esc(
+                    data.explanation || ""
+                )}</p>`;
+            }
+        } catch (e) {
+            if (rEl) rEl.textContent = "送信に失敗しました: " + e.message;
+        }
+    }
+
+    async function showQuizSummary() {
+        try {
+            const res = await fetch("/api/quiz/summary", { credentials: "same-origin" });
+            if (!res.ok) return;
+            const data = await res.json();
+            const acc = data.accuracy != null ? Math.round(data.accuracy * 1000) / 10 : 0;
+            const msg = `クイズ集計: 正答 ${data.correct || 0} / ${data.total || 0}（正答率 ${acc}%）`;
+            if (typeof displayMessage === "function") {
+                displayMessage(msg, "system-message");
+            } else {
+                alert(msg);
+            }
+        } catch (e) {
+            console.warn("quiz summary", e);
+        }
+    }
+
+    function patchFetch() {
+        const prev = window.fetch.bind(window);
+        window.fetch = async function (input, init) {
+            const res = await prev(input, init);
+            try {
+                const url = typeof input === "string" ? input : input.url;
+                if (url.includes("/api/watch/next") && res.ok) {
+                    const clone = res.clone();
+                    const data = await clone.json();
+                    if (data && data.quiz) {
+                        queueMicrotask(() => showQuizModal(data.quiz));
+                    }
+                }
+            } catch (e) {
+                console.warn("watch-quiz intercept", e);
+            }
+            return res;
+        };
+    }
+
+    function bindSessionEnd() {
+        const stopBtn = document.getElementById("stop-watch");
+        if (stopBtn) {
+            stopBtn.addEventListener("click", () => {
+                setTimeout(showQuizSummary, 300);
+            });
+        }
+        window.addEventListener("beforeunload", () => {
+            if (document.visibilityState !== "hidden") return;
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", () => {
+        patchFetch();
+        bindSessionEnd();
+    });
+})();

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -131,5 +131,6 @@
     <script src="{{ url_for('static', filename='js/security-utils.js') }}"></script>
     <script src="{{ url_for('static', filename='js/tts-common.js') }}"></script>
     <script src="{{ url_for('static', filename='js/chat.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/chat-enhancements.js') }}"></script>
 </body>
 </html>

--- a/templates/gamification.html
+++ b/templates/gamification.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>学習ダッシュボード - 職場コミュニケーション練習アプリ</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/modern.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/emergency-ui.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/dark-mode.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+    <script src="{{ url_for('static', filename='js/theme-toggle.js') }}"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+</head>
+<body>
+    <div id="chat-container">
+        <h1><i class="fas fa-chart-pie"></i> 学習ダッシュボード</h1>
+
+        <div class="content-section">
+            <p class="mode-description">スキルXP・クエスト・バッジ・成長推移・分析をまとめて確認できます。</p>
+
+            <div id="dashboard-error" class="error-message" style="display:none;"></div>
+
+            <section class="card-shadow" style="margin-bottom:1.5rem;">
+                <h2><i class="fas fa-bolt"></i> スキルXP</h2>
+                <div id="xp-bars-container"></div>
+            </section>
+
+            <section class="card-shadow" style="margin-bottom:1.5rem;">
+                <h2><i class="fas fa-tasks"></i> クエスト</h2>
+                <div id="quests-daily"></div>
+                <div id="quests-weekly"></div>
+            </section>
+
+            <section class="card-shadow" style="margin-bottom:1.5rem;">
+                <h2><i class="fas fa-medal"></i> バッジ</h2>
+                <div id="badge-grid" class="features-grid"></div>
+            </section>
+
+            <section class="card-shadow" style="margin-bottom:1.5rem;">
+                <h2><i class="fas fa-chart-line"></i> 成長（直近の平均）</h2>
+                <canvas id="growth-chart" height="120" aria-label="成長チャート"></canvas>
+            </section>
+
+            <section class="card-shadow" style="margin-bottom:1.5rem;">
+                <h2><i class="fas fa-chart-bar"></i> 分析</h2>
+                <div id="analytics-practice"></div>
+                <div id="analytics-skills"></div>
+                <div id="analytics-weakness"></div>
+            </section>
+
+            <section class="card-shadow" style="margin-bottom:1.5rem;">
+                <h2><i class="fas fa-download"></i> エクスポート</h2>
+                <p>会話履歴をダウンロードします（現在のセッション内容は空の場合はヘッダのみ）。</p>
+                <div class="action-buttons">
+                    <button type="button" id="btn-export-csv" class="secondary-button"><i class="fas fa-file-csv"></i> CSV</button>
+                    <button type="button" id="btn-export-json" class="secondary-button"><i class="fas fa-file-code"></i> JSON</button>
+                </div>
+            </section>
+        </div>
+    </div>
+
+    <div class="navigation">
+        <a href="{{ url_for('main.index') }}" class="nav-button">
+            <i class="fas fa-home"></i> トップページに戻る
+        </a>
+        {% if feature_flags.learning_history %}
+        <a href="{{ url_for('journal.view_journal') }}" class="nav-button">
+            <i class="fas fa-book"></i> 学習履歴を見る
+        </a>
+        {% endif %}
+    </div>
+
+    <script src="{{ url_for('static', filename='js/csrf-manager.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/gamification-dashboard.js') }}"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -178,6 +178,15 @@
                             <i class="fas fa-eye"></i> 観戦する
                         </a>
                     </div>
+
+                    <div class="feature-card card-shadow">
+                        <div class="feature-icon"><i class="fas fa-chart-pie"></i></div>
+                        <h3>学習ダッシュボード</h3>
+                        <p>スキルXP・クエスト・バッジ・成長グラフ・分析・エクスポートをまとめて確認できます。</p>
+                        <a href="{{ url_for('gamification_page.gamification_dashboard') }}" class="primary-button">
+                            <i class="fas fa-chart-line"></i> ダッシュボードを開く
+                        </a>
+                    </div>
                     
                     <div class="feature-card card-shadow" id="learning-history-card" style="display: none;">
                         <div class="feature-icon"><i class="fas fa-book"></i></div>
@@ -211,6 +220,7 @@
 
     <script src="{{ url_for('static', filename='js/csrf-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/model-selection.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/tutorial-overlay.js') }}"></script>
 </body>
 </html>
 

--- a/templates/watch.html
+++ b/templates/watch.html
@@ -79,6 +79,8 @@
                 </div>
             </div>
 
+            <div id="three-way-root"></div>
+
             <div class="action-buttons">
                 <button id="start-watch" class="primary-button">
                     <i class="fas fa-play"></i> 観戦を始める
@@ -120,5 +122,7 @@
 
     <script src="{{ url_for('static', filename='js/csrf-manager.js') }}"></script>
     <script src="{{ url_for('static', filename='js/watch.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/watch-quiz.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/three-way.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- ゲーミフィケーションダッシュボード画面（/gamification）
- チャット画面にリアルタイムフィードバック・モデレーション警告・要約ボタン追加
- 観戦画面にクイズモーダル・3者会話参加/退出ボタン追加
- 初回訪問チュートリアルオーバーレイ
- 全JSファイルは既存のfetch API + DOMContentLoadedパターンに準拠

## Test plan

- [ ] /gamification ページが200で表示される
- [ ] 全5 JSファイルが/static/js/から配信される
- [ ] 既存テスト375件に回帰なし
- [ ] チャット画面でリアルタイムフィードバックが表示される
- [ ] 観戦画面でクイズモーダルが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cacc-lab/workplace-roleplay/pull/39" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 学習ダッシュボードページを追加（XP、クエスト、バッジ、成長チャート、分析、CSV/JSONエクスポート）
  * チャットにモデレーション警告、リアルタイムフィードバック、要約表示を追加
  * 3者会話ワークフローを追加（参加・送信・退出）
  * チュートリアルオーバーレイを導入（初回表示、ステップ進行、スキップ）
  * ウォッチモードでのクイズ出題／回答／集計を追加
  * ホームとウォッチ画面に関連スクリプトとマウントポイントを追加
  * CSRF保護対象に新APIパスを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->