### PR TITLE
feat: Supabase統合（DB・認証・会話永続化）

### DIFF
--- a/.kiro/specs/supabase-integration/design.md
+++ b/.kiro/specs/supabase-integration/design.md
@@ -1,0 +1,163 @@
+# Supabase統合 設計書
+
+## テーブル設計
+
+### user_profiles
+```sql
+CREATE TABLE user_profiles (
+    id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    display_name TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+### skill_xp
+```sql
+CREATE TABLE skill_xp (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    empathy INT DEFAULT 0,
+    clarity INT DEFAULT 0,
+    active_listening INT DEFAULT 0,
+    adaptability INT DEFAULT 0,
+    positivity INT DEFAULT 0,
+    professionalism INT DEFAULT 0,
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(user_id)
+);
+```
+
+### xp_history
+```sql
+CREATE TABLE xp_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    source TEXT NOT NULL,
+    scenario_id TEXT,
+    xp_gains JSONB NOT NULL DEFAULT '{}',
+    scores_snapshot JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX idx_xp_history_user ON xp_history(user_id, created_at DESC);
+```
+
+### scenario_completions
+```sql
+CREATE TABLE scenario_completions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    scenario_id TEXT NOT NULL,
+    difficulty TEXT DEFAULT 'beginner',
+    count INT DEFAULT 1,
+    best_scores JSONB DEFAULT '{}',
+    first_completed_at TIMESTAMPTZ DEFAULT NOW(),
+    last_completed_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(user_id, scenario_id)
+);
+```
+
+### badges
+```sql
+CREATE TABLE badges (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    badge_id TEXT NOT NULL,
+    earned_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(user_id, badge_id)
+);
+```
+
+### quests
+```sql
+CREATE TABLE quests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    quest_id TEXT NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('daily', 'weekly')),
+    description TEXT,
+    target_key TEXT,
+    target_value INT DEFAULT 1,
+    current_value INT DEFAULT 0,
+    bonus_xp INT DEFAULT 0,
+    completed BOOLEAN DEFAULT FALSE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX idx_quests_user_active ON quests(user_id, completed, expires_at);
+```
+
+### conversations
+```sql
+CREATE TABLE conversations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    mode TEXT NOT NULL CHECK (mode IN ('scenario', 'chat', 'watch')),
+    scenario_id TEXT,
+    history JSONB NOT NULL DEFAULT '[]',
+    summary JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX idx_conversations_user ON conversations(user_id, created_at DESC);
+CREATE INDEX idx_conversations_mode ON conversations(user_id, mode);
+```
+
+### quiz_history
+```sql
+CREATE TABLE quiz_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    question TEXT,
+    choices JSONB,
+    correct_answer INT,
+    user_answer INT,
+    is_correct BOOLEAN,
+    xp_earned INT DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+### user_stats
+```sql
+CREATE TABLE user_stats (
+    user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    total_scenarios_completed INT DEFAULT 0,
+    total_quizzes_answered INT DEFAULT 0,
+    total_quizzes_correct INT DEFAULT 0,
+    consecutive_days INT DEFAULT 0,
+    unique_scenarios_tried INT DEFAULT 0,
+    last_activity_date DATE,
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+## RLS (Row Level Security)
+
+全テーブルに以下のポリシーを適用:
+```sql
+ALTER TABLE {table} ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Users can only access own data"
+    ON {table} FOR ALL
+    USING (auth.uid() = user_id);
+```
+
+## サービス層アーキテクチャ
+
+```
+SupabaseClient (シングルトン)
+    ↓
+SupabaseUserDataService (UserDataService と同じインターフェース)
+    ↓ フォールバック
+UserDataService (JSONファイル、Supabase未設定時)
+```
+
+## 認証フロー
+
+```
+未ログイン → ゲストモード（セッションUUID、既存動作）
+    ↓ 登録/ログイン
+ログイン済み → Supabase Auth UID でデータアクセス
+    ↓ オプション
+ゲストデータ → アカウントに紐づけ（マイグレーション）
+```

--- a/.kiro/specs/supabase-integration/requirements.md
+++ b/.kiro/specs/supabase-integration/requirements.md
@@ -1,0 +1,49 @@
+# Supabase統合 要件定義
+
+## 要件 1: Supabase DB統合
+
+**ユーザーストーリー:** 開発者として、JSONファイルベースの永続化をSupabase PostgreSQLに移行し、同時アクセス・検索・集計を可能にしたい。
+
+### 受入基準
+
+1. WHEN アプリケーションが起動した時 THEN Supabase PostgreSQLに接続する SHALL
+2. WHEN ユーザーデータを保存する時 THEN Supabase DBのテーブルに永続化する SHALL
+3. WHEN ユーザーデータを取得する時 THEN Supabase DBから読み込む SHALL
+4. WHEN Supabase接続が失敗した時 THEN JSONファイルにフォールバックする SHALL
+5. WHEN 既存のJSONデータがある時 THEN DBへマイグレーションできる SHALL
+
+---
+
+## 要件 2: Supabase Auth統合
+
+**ユーザーストーリー:** ユーザーとして、メールアドレスとパスワードで登録・ログインし、端末を変えてもデータを引き継ぎたい。
+
+### 受入基準
+
+1. WHEN ユーザーが登録画面にアクセスした時 THEN メール/パスワードで登録できる SHALL
+2. WHEN ユーザーがログインした時 THEN Supabase Auth でセッションを確立する SHALL
+3. WHEN ログイン済みユーザーがアクセスした時 THEN Auth UIDでデータを紐づける SHALL
+4. WHEN 未ログインユーザーがアクセスした時 THEN 従来のセッションUUIDで動作する SHALL（ゲスト利用）
+5. WHEN ゲストユーザーがログインした時 THEN ゲスト期間のデータをアカウントに紐づけできる SHALL
+
+---
+
+## 要件 3: 会話履歴の永続化
+
+**ユーザーストーリー:** ユーザーとして、過去の会話履歴がセッションをまたいで保存され、検索・振り返りができるようにしたい。
+
+### 受入基準
+
+1. WHEN シナリオ/雑談/観戦の会話が行われた時 THEN 会話履歴をDBに保存する SHALL
+2. WHEN ユーザーが過去の会話を閲覧する時 THEN DB から会話履歴を取得できる SHALL
+3. WHEN 会話履歴を検索する時 THEN モード・日付・キーワードでフィルタできる SHALL
+4. WHEN 会話をエクスポートする時 THEN DB からCSV/JSON形式で出力できる SHALL
+
+---
+
+## 設計原則
+
+- Supabase クライアントは環境変数（SUPABASE_URL, SUPABASE_KEY）で設定
+- 既存の UserDataService インターフェースを維持（SupabaseUserDataService で差し替え）
+- Row Level Security (RLS) でユーザーごとのデータ分離
+- Supabase 未設定時はJSONファイルにフォールバック（後方互換）

--- a/.kiro/specs/supabase-integration/tasks.md
+++ b/.kiro/specs/supabase-integration/tasks.md
@@ -1,0 +1,56 @@
+# 実装計画: Supabase統合
+
+## タスク
+
+- [ ] 1. Supabaseクライアント基盤
+  - [ ] 1.1 `services/supabase_client.py` — シングルトン接続、環境変数読み込み、フォールバック判定
+  - [ ] 1.2 テスト: 接続成功/失敗、フォールバック動作
+  - _要件: 1.1, 1.4_
+
+- [ ] 2. DBテーブル作成
+  - [ ] 2.1 SQLマイグレーションファイル作成（`migrations/001_initial.sql`）
+  - [ ] 2.2 Supabase Dashboard or CLI でテーブル作成
+  - [ ] 2.3 RLSポリシー適用
+  - _要件: 1.1_
+
+- [ ] 3. SupabaseUserDataService
+  - [ ] 3.1 `services/supabase_user_data_service.py` — UserDataServiceと同じインターフェース
+  - [ ] 3.2 get_user_data: DBから読み込み、未登録時はデフォルト作成
+  - [ ] 3.3 save_user_data: DBに書き込み（UPSERT）
+  - [ ] 3.4 テスト: CRUD、デフォルト作成、フォールバック
+  - _要件: 1.2, 1.3, 1.4_
+
+- [ ] 4. データマイグレーションツール
+  - [ ] 4.1 `scripts/migrate_json_to_supabase.py` — 既存JSONデータをDBに移行
+  - [ ] 4.2 テスト: マイグレーション前後のデータ整合
+  - _要件: 1.5_
+
+- [ ] 5. 認証サービス
+  - [ ] 5.1 `services/supabase_auth_service.py` — sign_up, sign_in, sign_out, get_current_user
+  - [ ] 5.2 `routes/auth_routes.py` — /auth/register, /auth/login, /auth/logout, /auth/me
+  - [ ] 5.3 `templates/auth.html` — 登録/ログインフォーム
+  - [ ] 5.4 テスト: 登録、ログイン、ログアウト、ゲスト動作
+  - _要件: 2.1, 2.2, 2.3, 2.4_
+
+- [ ] 6. ゲストデータ紐づけ
+  - [ ] 6.1 ゲストUUIDのデータをAuth UIDに移行するサービス
+  - [ ] 6.2 テスト: 紐づけ前後のデータ整合
+  - _要件: 2.5_
+
+- [ ] 7. 会話履歴永続化
+  - [ ] 7.1 `services/conversation_persistence_service.py` — 会話のDB保存/取得/検索
+  - [ ] 7.2 既存ルートに保存フック追加（scenario_routes, chat_routes, watch_routes）
+  - [ ] 7.3 `routes/history_routes.py` 拡張 — 検索・フィルタAPI
+  - [ ] 7.4 テスト: 保存、取得、検索、エクスポート連携
+  - _要件: 3.1, 3.2, 3.3, 3.4_
+
+- [ ] 8. UserDataService切り替え
+  - [ ] 8.1 環境変数でSupabase/JSONを切り替えるファクトリ関数
+  - [ ] 8.2 全サービス・ルートのUserDataServiceをファクトリ経由に変更
+  - [ ] 8.3 テスト: 切り替え動作確認
+  - _要件: 1.4_
+
+- [ ] 9. 最終チェックポイント
+  - 全テストPASS
+  - Supabase設定時: DBで動作
+  - Supabase未設定時: JSONフォールバックで既存動作維持

--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -1,0 +1,198 @@
+-- Supabase 初期スキーマ（.kiro/specs/supabase-integration/design.md 準拠）
+-- auth.users は Supabase が提供
+
+-- ---------------------------------------------------------------------------
+-- user_profiles
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.user_profiles (
+    id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    display_name TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.user_profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own profile"
+    ON public.user_profiles FOR ALL
+    USING (auth.uid() = id)
+    WITH CHECK (auth.uid() = id);
+
+-- ---------------------------------------------------------------------------
+-- skill_xp
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.skill_xp (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    empathy INT DEFAULT 0,
+    clarity INT DEFAULT 0,
+    active_listening INT DEFAULT 0,
+    adaptability INT DEFAULT 0,
+    positivity INT DEFAULT 0,
+    professionalism INT DEFAULT 0,
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(user_id)
+);
+
+ALTER TABLE public.skill_xp ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own data"
+    ON public.skill_xp FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- xp_history
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.xp_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    source TEXT NOT NULL,
+    scenario_id TEXT,
+    xp_gains JSONB NOT NULL DEFAULT '{}',
+    scores_snapshot JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_xp_history_user ON public.xp_history(user_id, created_at DESC);
+
+ALTER TABLE public.xp_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own data"
+    ON public.xp_history FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- scenario_completions
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.scenario_completions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    scenario_id TEXT NOT NULL,
+    difficulty TEXT DEFAULT 'beginner',
+    count INT DEFAULT 1,
+    best_scores JSONB DEFAULT '{}',
+    first_completed_at TIMESTAMPTZ DEFAULT NOW(),
+    last_completed_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(user_id, scenario_id)
+);
+
+ALTER TABLE public.scenario_completions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own data"
+    ON public.scenario_completions FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- badges
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.badges (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    badge_id TEXT NOT NULL,
+    earned_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(user_id, badge_id)
+);
+
+ALTER TABLE public.badges ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own data"
+    ON public.badges FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- quests
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.quests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    quest_id TEXT NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('daily', 'weekly')),
+    description TEXT,
+    target_key TEXT,
+    target_value INT DEFAULT 1,
+    current_value INT DEFAULT 0,
+    bonus_xp INT DEFAULT 0,
+    completed BOOLEAN DEFAULT FALSE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_quests_user_active ON public.quests(user_id, completed, expires_at);
+
+ALTER TABLE public.quests ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own data"
+    ON public.quests FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- conversations
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.conversations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    mode TEXT NOT NULL CHECK (mode IN ('scenario', 'chat', 'watch')),
+    scenario_id TEXT,
+    history JSONB NOT NULL DEFAULT '[]',
+    summary JSONB,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversations_user ON public.conversations(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_conversations_mode ON public.conversations(user_id, mode);
+
+ALTER TABLE public.conversations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own data"
+    ON public.conversations FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- quiz_history
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.quiz_history (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    question TEXT,
+    choices JSONB,
+    correct_answer INT,
+    user_answer INT,
+    is_correct BOOLEAN,
+    xp_earned INT DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.quiz_history ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own data"
+    ON public.quiz_history FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
+-- user_stats
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.user_stats (
+    user_id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    total_scenarios_completed INT DEFAULT 0,
+    total_quizzes_answered INT DEFAULT 0,
+    total_quizzes_correct INT DEFAULT 0,
+    consecutive_days INT DEFAULT 0,
+    unique_scenarios_tried INT DEFAULT 0,
+    last_activity_date DATE,
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.user_stats ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own data"
+    ON public.user_stats FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);

--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -2,6 +2,25 @@
 -- auth.users は Supabase が提供
 
 -- ---------------------------------------------------------------------------
+-- user_data (SupabaseUserDataService が参照する汎用テーブル)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.user_data (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    data JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(user_id)
+);
+
+ALTER TABLE public.user_data ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can only access own user_data"
+    ON public.user_data FOR ALL
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- ---------------------------------------------------------------------------
 -- user_profiles
 -- ---------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS public.user_profiles (

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,5 +38,8 @@ bleach>=6.0.0
 python-json-logger>=2.0.0
 vibelogger>=0.1.0
 
+# ========== DATABASE & AUTH ==========
+supabase>=2.0.0
+
 # ========== API DOCUMENTATION ==========
 flasgger>=0.9.7

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -31,6 +31,15 @@ def register_blueprints(app: Flask):
     except ImportError as e:
         print(f"⚠️ メインルートは利用できません: {e}")
 
+    # 認証ルート（Supabase Auth）
+    try:
+        from routes.auth_routes import auth_bp
+
+        app.register_blueprint(auth_bp)
+        print("✅ 認証ルートを登録しました (/auth/*)")
+    except ImportError as e:
+        print(f"⚠️ 認証ルートは利用できません: {e}")
+
     # チャットルート
     try:
         from routes.chat_routes import chat_bp

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -1,0 +1,136 @@
+"""
+認証（Supabase Auth）用ルート
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from flask import Blueprint, jsonify, render_template, request, session
+
+from services.supabase_auth_service import SupabaseAuthService
+from services.supabase_client import get_supabase_client_manager
+
+auth_bp = Blueprint("auth", __name__, url_prefix="/auth")
+
+SESSION_TOKEN_KEY = "supabase_access_token"
+
+
+def _auth_service() -> Optional[SupabaseAuthService]:
+    client = get_supabase_client_manager().get_client()
+    if client is None:
+        return None
+    return SupabaseAuthService(client)
+
+
+def _access_token_from_session_obj(sess: Any) -> Optional[str]:
+    if sess is None:
+        return None
+    if isinstance(sess, dict):
+        return sess.get("access_token")
+    return getattr(sess, "access_token", None)
+
+
+def _user_to_jsonable(user: Any) -> Optional[Dict[str, Any]]:
+    if user is None:
+        return None
+    if isinstance(user, dict):
+        return user
+    if hasattr(user, "model_dump"):
+        try:
+            return user.model_dump()
+        except Exception:
+            pass
+    out: Dict[str, Any] = {}
+    for key in ("id", "email", "phone", "created_at", "app_metadata", "user_metadata"):
+        if hasattr(user, key):
+            out[key] = getattr(user, key)
+    return out if out else {"repr": str(user)}
+
+
+@auth_bp.route("/login", methods=["GET"])
+def login_page():
+    """ログイン・登録画面"""
+    return render_template("auth.html")
+
+
+@auth_bp.route("/api/register", methods=["POST"])
+def api_register():
+    """POST /auth/api/register → sign_up → JSON"""
+    try:
+        svc = _auth_service()
+        if svc is None:
+            return jsonify({"user": None, "error": "Supabaseが設定されていません"}), 503
+        data = request.get_json(silent=True) or {}
+        email = (data.get("email") or "").strip()
+        password = data.get("password")
+        result = svc.sign_up(email, password)
+        if result.get("error"):
+            return jsonify({"user": None, "error": result["error"]}), 400
+        return jsonify({"user": _user_to_jsonable(result.get("user")), "error": None}), 200
+    except Exception as e:
+        return jsonify({"user": None, "error": str(e)}), 500
+
+
+@auth_bp.route("/api/login", methods=["POST"])
+def api_login():
+    """POST /auth/api/login → sign_in → session に token → JSON"""
+    try:
+        svc = _auth_service()
+        if svc is None:
+            return jsonify({"user": None, "session": None, "error": "Supabaseが設定されていません"}), 503
+        data = request.get_json(silent=True) or {}
+        email = (data.get("email") or "").strip()
+        password = data.get("password")
+        result = svc.sign_in(email, password)
+        if result.get("error"):
+            return jsonify({"user": None, "session": None, "error": result["error"]}), 400
+        sess = result.get("session")
+        token = _access_token_from_session_obj(sess)
+        if token:
+            session[SESSION_TOKEN_KEY] = token
+        return (
+            jsonify(
+                {
+                    "user": _user_to_jsonable(result.get("user")),
+                    "session": None,
+                    "error": None,
+                }
+            ),
+            200,
+        )
+    except Exception as e:
+        return jsonify({"user": None, "session": None, "error": str(e)}), 500
+
+
+@auth_bp.route("/api/logout", methods=["POST"])
+def api_logout():
+    """POST /auth/api/logout → sign_out → session 削除 → JSON"""
+    try:
+        svc = _auth_service()
+        if svc is not None:
+            try:
+                svc.sign_out()
+            except Exception:
+                pass
+        session.pop(SESSION_TOKEN_KEY, None)
+        return jsonify({"success": True}), 200
+    except Exception as e:
+        session.pop(SESSION_TOKEN_KEY, None)
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@auth_bp.route("/api/me", methods=["GET"])
+def api_me():
+    """GET /auth/api/me → 現在のユーザー情報 JSON"""
+    try:
+        svc = _auth_service()
+        if svc is None:
+            return jsonify({"error": "Supabaseが設定されていません"}), 503
+        token = session.get(SESSION_TOKEN_KEY)
+        result = svc.get_current_user(token)
+        if result is None:
+            return jsonify({"user": None}), 401
+        return jsonify({"user": _user_to_jsonable(result.get("user"))}), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500

--- a/services/conversation_persistence_service.py
+++ b/services/conversation_persistence_service.py
@@ -36,7 +36,7 @@ class ConversationPersistenceService:
         return {"id": None}
 
     def get_conversations(self, user_id: str, mode: str, limit: int) -> List[Dict[str, Any]]:
-        lim = max(1, int(limit))
+        lim = max(1, min(int(limit), 100))
         res = (
             self._client.table(self.TABLE)
             .select("*")
@@ -50,7 +50,12 @@ class ConversationPersistenceService:
 
     def search_conversations(self, user_id: str, keyword: str) -> List[Dict[str, Any]]:
         kw = (keyword or "").strip()
-        res = self._client.table(self.TABLE).select("*").eq("user_id", user_id).execute()
+        res = (
+            self._client.table(self.TABLE)
+            .select("*")
+            .eq("user_id", user_id)
+            .execute()
+        )
         data = getattr(res, "data", None)
         if not isinstance(data, list):
             return []

--- a/services/conversation_persistence_service.py
+++ b/services/conversation_persistence_service.py
@@ -1,0 +1,66 @@
+"""
+会話履歴の永続化（Supabase テーブル想定）
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+class ConversationPersistenceService:
+    TABLE = "conversations"
+
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def save_conversation(
+        self,
+        user_id: str,
+        mode: str,
+        history: List[Any],
+        scenario_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        row: Dict[str, Any] = {
+            "user_id": user_id,
+            "mode": mode,
+            "history": history or [],
+        }
+        if scenario_id is not None:
+            row["scenario_id"] = scenario_id
+        res = self._client.table(self.TABLE).insert(row).execute()
+        data = getattr(res, "data", None)
+        if isinstance(data, list) and len(data) > 0 and isinstance(data[0], dict):
+            rid = data[0].get("id")
+            if rid is not None:
+                return {"id": rid}
+        return {"id": None}
+
+    def get_conversations(self, user_id: str, mode: str, limit: int) -> List[Dict[str, Any]]:
+        lim = max(1, int(limit))
+        res = (
+            self._client.table(self.TABLE)
+            .select("*")
+            .eq("user_id", user_id)
+            .eq("mode", mode)
+            .limit(lim)
+            .execute()
+        )
+        data = getattr(res, "data", None)
+        return list(data) if isinstance(data, list) else []
+
+    def search_conversations(self, user_id: str, keyword: str) -> List[Dict[str, Any]]:
+        kw = (keyword or "").strip()
+        res = self._client.table(self.TABLE).select("*").eq("user_id", user_id).execute()
+        data = getattr(res, "data", None)
+        if not isinstance(data, list):
+            return []
+        if not kw:
+            return list(data)
+        out: List[Dict[str, Any]] = []
+        for row in data:
+            if not isinstance(row, dict):
+                continue
+            blob = str(row.get("history", "")) + str(row.get("mode", "")) + str(row.get("scenario_id", ""))
+            if kw.lower() in blob.lower():
+                out.append(row)
+        return out

--- a/services/supabase_auth_service.py
+++ b/services/supabase_auth_service.py
@@ -1,0 +1,58 @@
+"""
+Supabase Auth 操作の薄いラッパー
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+class SupabaseAuthService:
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def sign_up(self, email: str, password: str) -> Dict[str, Any]:
+        if password is None or str(password).strip() == "":
+            return {"user": None, "error": "パスワードは必須です"}
+        try:
+            res = self._client.auth.sign_up({"email": email, "password": password})
+            user = getattr(res, "user", None)
+            err = getattr(res, "error", None)
+            if err is not None:
+                return {"user": None, "error": str(err)}
+            return {"user": user, "error": None}
+        except Exception as e:
+            return {"user": None, "error": str(e)}
+
+    def sign_in(self, email: str, password: str) -> Dict[str, Any]:
+        if password is None or str(password).strip() == "":
+            return {"user": None, "session": None, "error": "パスワードは必須です"}
+        try:
+            res = self._client.auth.sign_in_with_password({"email": email, "password": password})
+            user = getattr(res, "user", None)
+            session = getattr(res, "session", None)
+            err = getattr(res, "error", None)
+            if err is not None:
+                return {"user": None, "session": None, "error": str(err)}
+            return {"user": user, "session": session, "error": None}
+        except Exception as e:
+            return {"user": None, "session": None, "error": str(e)}
+
+    def sign_out(self) -> Dict[str, Any]:
+        try:
+            self._client.auth.sign_out()
+            return {"success": True}
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+
+    def get_current_user(self, token: Optional[str]) -> Optional[Dict[str, Any]]:
+        if not token or not str(token).strip():
+            return None
+        try:
+            res = self._client.auth.get_user(token)
+            user = getattr(res, "user", None)
+            if user is None:
+                return None
+            return {"user": user}
+        except Exception:
+            return None

--- a/services/supabase_client.py
+++ b/services/supabase_client.py
@@ -1,0 +1,82 @@
+"""
+Supabase クライアント管理（未設定・接続失敗時は JSON 版 UserDataService にフォールバック）
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional, Union
+
+from services.supabase_user_data_service import SupabaseUserDataService
+from services.user_data_service import UserDataService
+
+# 環境変数名（プロジェクトで統一）
+ENV_SUPABASE_URL = "SUPABASE_URL"
+ENV_SUPABASE_KEY = "SUPABASE_KEY"
+
+_supabase_client_manager_instance: Optional["SupabaseClientManager"] = None
+
+
+def get_supabase_client_manager() -> "SupabaseClientManager":
+    """アプリ全体で共有する SupabaseClientManager（クライアントキャッシュを一元化）。"""
+    global _supabase_client_manager_instance
+    if _supabase_client_manager_instance is None:
+        _supabase_client_manager_instance = SupabaseClientManager()
+    return _supabase_client_manager_instance
+
+
+class SupabaseClientManager:
+    """Supabase クライアントの遅延生成と UserDataService の選択。"""
+
+    def __init__(self) -> None:
+        self._client_cache: Optional[Any] = None
+        self._client_attempted = False
+
+    def reset(self) -> None:
+        """テスト用: キャッシュをクリア"""
+        self._client_cache = None
+        self._client_attempted = False
+
+    @staticmethod
+    def _env_configured() -> bool:
+        url = (os.environ.get(ENV_SUPABASE_URL) or "").strip()
+        key = (os.environ.get(ENV_SUPABASE_KEY) or "").strip()
+        return bool(url and key)
+
+    def is_available(self) -> bool:
+        """SUPABASE_URL / SUPABASE_KEY がともに非空なら True（接続可否とは独立）。"""
+        return self._env_configured()
+
+    def get_client(self) -> Optional[Any]:
+        """
+        supabase.Client を返す。未設定・import 失敗・create_client 失敗時は None。
+        """
+        if not self._env_configured():
+            return None
+        if self._client_cache is not None:
+            return self._client_cache
+        if self._client_attempted:
+            return None
+        self._client_attempted = True
+        try:
+            from supabase import create_client  # type: ignore
+        except ImportError:
+            self._client_cache = None
+            return None
+        try:
+            url = os.environ[ENV_SUPABASE_URL].strip()
+            key = os.environ[ENV_SUPABASE_KEY].strip()
+            self._client_cache = create_client(url, key)
+        except Exception:
+            self._client_cache = None
+        return self._client_cache
+
+    def get_user_data_service(self) -> Union[UserDataService, SupabaseUserDataService]:
+        """
+        クライアント取得に成功した場合は SupabaseUserDataService、
+        それ以外は JSON ファイル版 UserDataService。
+        """
+        client = self.get_client()
+        if client is None:
+            return UserDataService()
+        return SupabaseUserDataService(client)

--- a/services/supabase_user_data_service.py
+++ b/services/supabase_user_data_service.py
@@ -1,0 +1,56 @@
+"""
+Supabase 上のユーザーデータ（user_data テーブル想定）
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from services.gamification_constants import utc_now_iso
+from services.user_data_service import UserDataService
+
+
+class SupabaseUserDataService(UserDataService):
+    """user_id + data(JSON) を UPSERT で永続化する UserDataService。"""
+
+    TABLE = "user_data"
+
+    def __init__(self, client: Any, data_dir: Optional[str] = None) -> None:
+        super().__init__(data_dir=data_dir)
+        self._client = client
+
+    def get_user_data(self, user_id: str) -> Dict[str, Any]:
+        if not user_id or not isinstance(user_id, str):
+            raise ValueError("user_id must be a non-empty string")
+        try:
+            res = (
+                self._client.table(self.TABLE)
+                .select("data")
+                .eq("user_id", user_id.strip())
+                .limit(1)
+                .execute()
+            )
+            rows = getattr(res, "data", None)
+            if isinstance(rows, list) and len(rows) > 0:
+                row = rows[0]
+                if isinstance(row, dict):
+                    d = row.get("data")
+                    if isinstance(d, dict):
+                        return d
+            return self._create_default_data(user_id)
+        except Exception:
+            return self._create_default_data(user_id)
+
+    def save_user_data(self, user_id: str, data: Dict[str, Any]) -> None:
+        if data is None or not isinstance(data, dict):
+            raise TypeError("data must be a dict")
+        payload = dict(data)
+        payload["user_id"] = user_id
+        payload["updated_at"] = utc_now_iso()
+        if "created_at" not in payload:
+            payload["created_at"] = payload["updated_at"]
+        row = {
+            "user_id": user_id,
+            "data": payload,
+        }
+        self._client.table(self.TABLE).upsert(row).execute()

--- a/services/user_data_factory.py
+++ b/services/user_data_factory.py
@@ -1,0 +1,19 @@
+"""
+UserDataService の取得（環境に応じて JSON 版 / Supabase 版）
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from services.supabase_client import get_supabase_client_manager
+from services.supabase_user_data_service import SupabaseUserDataService
+from services.user_data_service import UserDataService
+
+
+def get_user_data_service() -> Union[UserDataService, SupabaseUserDataService]:
+    """
+    SUPABASE_URL / SUPABASE_KEY が有効に設定されクライアント生成に成功した場合は
+    SupabaseUserDataService、それ以外は JSON ファイル版 UserDataService。
+    """
+    return get_supabase_client_manager().get_user_data_service()

--- a/templates/auth.html
+++ b/templates/auth.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ログイン・登録 | 職場コミュニケーション練習アプリ</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/modern.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/emergency-ui.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/dark-mode.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/responsive.css') }}">
+    <script src="{{ url_for('static', filename='js/theme-toggle.js') }}"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+</head>
+<body>
+    <div id="chat-container">
+        <h1><i class="fas fa-user-circle"></i> アカウント</h1>
+
+        <div class="content-section">
+            <div class="welcome-section">
+                <p class="auth-intro">メールアドレスとパスワードでログインするか、新規登録してください。</p>
+
+                <div class="auth-tab-row" role="tablist" aria-label="ログインまたは登録">
+                    <button type="button" class="primary-button auth-tab-btn" id="tab-login" role="tab" aria-selected="true" aria-controls="panel-login" data-panel="login">
+                        <i class="fas fa-sign-in-alt"></i> ログイン
+                    </button>
+                    <button type="button" class="secondary-button auth-tab-btn" id="tab-register" role="tab" aria-selected="false" aria-controls="panel-register" data-panel="register">
+                        <i class="fas fa-user-plus"></i> 新規登録
+                    </button>
+                </div>
+
+                <div id="auth-message" class="welcome-section" role="status" aria-live="polite" style="display:none;"></div>
+
+                <div id="panel-login" class="auth-panel" role="tabpanel" aria-labelledby="tab-login">
+                    <form id="form-login" class="auth-form" novalidate>
+                        <div class="select-group">
+                            <label for="login-email">メールアドレス</label>
+                            <input type="email" id="login-email" name="email" required autocomplete="email" class="enhanced-select">
+                        </div>
+                        <div class="select-group">
+                            <label for="login-password">パスワード</label>
+                            <input type="password" id="login-password" name="password" required autocomplete="current-password" class="enhanced-select">
+                        </div>
+                        <button type="submit" class="primary-button"><i class="fas fa-sign-in-alt"></i> ログイン</button>
+                    </form>
+                </div>
+
+                <div id="panel-register" class="auth-panel" style="display:none;" role="tabpanel" aria-labelledby="tab-register">
+                    <form id="form-register" class="auth-form" novalidate>
+                        <div class="select-group">
+                            <label for="register-email">メールアドレス</label>
+                            <input type="email" id="register-email" name="email" required autocomplete="email" class="enhanced-select">
+                        </div>
+                        <div class="select-group">
+                            <label for="register-password">パスワード</label>
+                            <input type="password" id="register-password" name="password" required autocomplete="new-password" class="enhanced-select">
+                        </div>
+                        <button type="submit" class="primary-button"><i class="fas fa-user-plus"></i> 登録する</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+(function () {
+    var tabLogin = document.getElementById('tab-login');
+    var tabRegister = document.getElementById('tab-register');
+    var panelLogin = document.getElementById('panel-login');
+    var panelRegister = document.getElementById('panel-register');
+    var msgEl = document.getElementById('auth-message');
+
+    function showMessage(text, isError) {
+        msgEl.textContent = text || '';
+        msgEl.style.display = text ? 'block' : 'none';
+        msgEl.className = isError ? 'error-message' : 'welcome-section';
+    }
+
+    function setTab(panel) {
+        var isLogin = panel === 'login';
+        panelLogin.style.display = isLogin ? 'block' : 'none';
+        panelRegister.style.display = isLogin ? 'none' : 'block';
+        tabLogin.className = (isLogin ? 'primary-button' : 'secondary-button') + ' auth-tab-btn';
+        tabRegister.className = (isLogin ? 'secondary-button' : 'primary-button') + ' auth-tab-btn';
+        tabLogin.setAttribute('aria-selected', isLogin ? 'true' : 'false');
+        tabRegister.setAttribute('aria-selected', isLogin ? 'false' : 'true');
+    }
+
+    tabLogin.addEventListener('click', function () { setTab('login'); showMessage('', false); });
+    tabRegister.addEventListener('click', function () { setTab('register'); showMessage('', false); });
+
+    function postJson(url, body) {
+        return fetch(url, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, status: r.status, data: j }; }); });
+    }
+
+    document.getElementById('form-login').addEventListener('submit', function (e) {
+        e.preventDefault();
+        var email = document.getElementById('login-email').value.trim();
+        var password = document.getElementById('login-password').value;
+        showMessage('', false);
+        postJson('{{ url_for("auth.api_login") }}', { email: email, password: password })
+            .then(function (res) {
+                if (res.ok && !res.data.error) {
+                    showMessage('ログインに成功しました。トップへ移動します。', false);
+                    window.location.href = '{{ url_for("main.index") }}';
+                } else {
+                    showMessage(res.data.error || 'ログインに失敗しました', true);
+                }
+            })
+            .catch(function () { showMessage('通信エラーが発生しました', true); });
+    });
+
+    document.getElementById('form-register').addEventListener('submit', function (e) {
+        e.preventDefault();
+        var email = document.getElementById('register-email').value.trim();
+        var password = document.getElementById('register-password').value;
+        showMessage('', false);
+        postJson('{{ url_for("auth.api_register") }}', { email: email, password: password })
+            .then(function (res) {
+                if (res.ok && !res.data.error) {
+                    showMessage('登録が完了しました。ログインタブからサインインしてください。', false);
+                    setTab('login');
+                    document.getElementById('login-email').value = email;
+                } else {
+                    showMessage(res.data.error || '登録に失敗しました', true);
+                }
+            })
+            .catch(function () { showMessage('通信エラーが発生しました', true); });
+    });
+})();
+    </script>
+</body>
+</html>

--- a/tests/test_services/test_conversation_persistence.py
+++ b/tests/test_services/test_conversation_persistence.py
@@ -1,0 +1,90 @@
+"""
+ConversationPersistenceService のユニットテスト（Supabase クライアントは Mock）
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from services.conversation_persistence_service import ConversationPersistenceService
+
+
+@pytest.fixture
+def mock_table():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_client(mock_table):
+    c = MagicMock()
+    c.table.return_value = mock_table
+    return c
+
+
+@pytest.fixture
+def svc(mock_client):
+    return ConversationPersistenceService(mock_client)
+
+
+class TestSaveConversation:
+    def test_save_success_returns_id(self, svc, mock_table):
+        # Given: insert が返す行に id が含まれる
+        # When: save_conversation を呼ぶ
+        # Then: dict(id) が返り insert が1回呼ばれる
+        mock_table.insert.return_value.execute.return_value = MagicMock(
+            data=[{"id": "row-1", "user_id": "u1", "mode": "chat"}]
+        )
+        r = svc.save_conversation("u1", "chat", [{"role": "user", "content": "hi"}], None)
+        assert r == {"id": "row-1"}
+        mock_table.insert.assert_called_once()
+
+    def test_empty_history_allowed(self, svc, mock_table):
+        # Given: 空の history を許容する insert 応答
+        # When: history=[] で保存する
+        # Then: id が返り payload の history は []
+        mock_table.insert.return_value.execute.return_value = MagicMock(data=[{"id": "e1"}])
+        r = svc.save_conversation("u1", "scenario", [], "sc1")
+        assert r["id"] == "e1"
+        call = mock_table.insert.call_args[0][0]
+        assert call["history"] == []
+
+
+class TestGetConversations:
+    def test_filter_by_mode(self, svc, mock_table):
+        # Given: user_id/mode で絞った select の結果が1件
+        # When: get_conversations(user_id, mode, limit)
+        # Then: 返却行の mode が一致する
+        mock_table.select.return_value.eq.return_value.eq.return_value.limit.return_value.execute.return_value = MagicMock(
+            data=[{"id": "1", "mode": "chat"}]
+        )
+        rows = svc.get_conversations("u1", "chat", 10)
+        assert len(rows) == 1
+        assert rows[0]["mode"] == "chat"
+
+    def test_limit_applied(self, svc, mock_table):
+        # Given: limit チェーンのモック
+        # When: limit=5 で取得
+        # Then: limit(5) が呼ばれる
+        lim_mock = mock_table.select.return_value.eq.return_value.eq.return_value.limit
+        lim_mock.return_value.execute.return_value = MagicMock(data=[])
+        svc.get_conversations("u1", "watch", 5)
+        lim_mock.assert_called_with(5)
+
+
+class TestSearchConversations:
+    def test_keyword_filter(self, svc, mock_table):
+        # Given: 全件取得相当のデータにキーワード一致/不一致が混在
+        # When: search_conversations(user_id, keyword)
+        # Then: キーワードを含むメッセージのみ残る
+        mock_table.select.return_value.eq.return_value.execute.return_value = MagicMock(
+            data=[
+                {"id": "a", "history": [{"content": "hello world"}], "mode": "chat"},
+                {"id": "b", "history": [{"content": "zzz"}], "mode": "chat"},
+            ]
+        )
+        rows = svc.search_conversations("u1", "hello")
+        assert len(rows) == 1
+        assert rows[0]["id"] == "a"

--- a/tests/test_services/test_supabase_auth_service.py
+++ b/tests/test_services/test_supabase_auth_service.py
@@ -1,0 +1,83 @@
+"""
+SupabaseAuthService のユニットテスト（Supabase クライアントは Mock）
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from services.supabase_auth_service import SupabaseAuthService
+
+
+@pytest.fixture
+def mock_auth():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_client(mock_auth):
+    c = MagicMock()
+    c.auth = mock_auth
+    return c
+
+
+@pytest.fixture
+def auth_svc(mock_client):
+    return SupabaseAuthService(mock_client)
+
+
+class TestSignUp:
+    def test_sign_up_success(self, auth_svc, mock_auth):
+        mock_user = {"id": "u1", "email": "a@b.com"}
+        mock_res = MagicMock()
+        mock_res.user = mock_user
+        mock_res.error = None
+        mock_auth.sign_up.return_value = mock_res
+
+        r = auth_svc.sign_up("a@b.com", "secret123")
+        assert r["error"] is None
+        assert r["user"] == mock_user
+        mock_auth.sign_up.assert_called_once()
+
+
+class TestSignIn:
+    def test_sign_in_success(self, auth_svc, mock_auth):
+        mock_res = MagicMock()
+        mock_res.user = {"id": "u1"}
+        mock_res.session = {"access_token": "tok"}
+        mock_res.error = None
+        mock_auth.sign_in_with_password.return_value = mock_res
+
+        r = auth_svc.sign_in("a@b.com", "secret123")
+        assert r["error"] is None
+        assert r["user"] is not None
+        assert r["session"] is not None
+
+
+class TestSignOut:
+    def test_sign_out_success(self, auth_svc, mock_auth):
+        mock_auth.sign_out.return_value = None
+        r = auth_svc.sign_out()
+        assert r["success"] is True
+        mock_auth.sign_out.assert_called_once()
+
+
+class TestGetCurrentUser:
+    def test_invalid_token_returns_none(self, auth_svc, mock_auth):
+        mock_auth.get_user.side_effect = Exception("invalid jwt")
+        assert auth_svc.get_current_user("bad") is None
+
+    def test_empty_password_sign_up_error(self, auth_svc, mock_auth):
+        r = auth_svc.sign_up("a@b.com", "")
+        assert r["user"] is None
+        assert r["error"] is not None
+        mock_auth.sign_up.assert_not_called()
+
+    def test_empty_password_sign_in_error(self, auth_svc, mock_auth):
+        r = auth_svc.sign_in("a@b.com", "   ")
+        assert r["user"] is None
+        assert r["error"] is not None
+        mock_auth.sign_in_with_password.assert_not_called()

--- a/tests/test_services/test_supabase_client.py
+++ b/tests/test_services/test_supabase_client.py
@@ -1,0 +1,90 @@
+"""
+SupabaseClientManager のユニットテスト（環境変数は monkeypatch）
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from services.supabase_client import (
+    ENV_SUPABASE_KEY,
+    ENV_SUPABASE_URL,
+    SupabaseClientManager,
+    SupabaseUserDataService,
+)
+from services.user_data_service import UserDataService
+
+
+@pytest.fixture
+def manager():
+    m = SupabaseClientManager()
+    m.reset()
+    yield m
+    m.reset()
+
+
+class TestIsAvailable:
+    def test_available_when_url_and_key_set(self, manager, monkeypatch):
+        monkeypatch.setenv(ENV_SUPABASE_URL, "https://example.supabase.co")
+        monkeypatch.setenv(ENV_SUPABASE_KEY, "test-key")
+        assert manager.is_available() is True
+
+    def test_not_available_when_unset(self, manager, monkeypatch):
+        monkeypatch.delenv(ENV_SUPABASE_URL, raising=False)
+        monkeypatch.delenv(ENV_SUPABASE_KEY, raising=False)
+        assert manager.is_available() is False
+
+
+class TestGetUserDataServiceJsonFallback:
+    def test_returns_plain_user_data_service_when_env_unset(self, manager, monkeypatch):
+        monkeypatch.delenv(ENV_SUPABASE_URL, raising=False)
+        monkeypatch.delenv(ENV_SUPABASE_KEY, raising=False)
+        svc = manager.get_user_data_service()
+        assert type(svc) is UserDataService
+        assert not hasattr(svc, "_client")
+
+
+class TestGetClientFallback:
+    def test_returns_json_user_data_when_client_fails(self, manager, monkeypatch):
+        monkeypatch.setenv(ENV_SUPABASE_URL, "https://example.supabase.co")
+        monkeypatch.setenv(ENV_SUPABASE_KEY, "test-key")
+
+        import types
+
+        fake_mod = types.ModuleType("supabase")
+
+        def boom(_url, _key):
+            raise RuntimeError("connection failed")
+
+        fake_mod.create_client = boom
+        monkeypatch.setitem(sys.modules, "supabase", fake_mod)
+
+        manager.reset()
+        assert manager.get_client() is None
+        svc = manager.get_user_data_service()
+        assert type(svc) is UserDataService
+
+
+class TestSupabaseUserDataWhenClientOk:
+    def test_returns_supabase_user_data_service_with_mock_client(self, manager, monkeypatch):
+        monkeypatch.setenv(ENV_SUPABASE_URL, "https://example.supabase.co")
+        monkeypatch.setenv(ENV_SUPABASE_KEY, "test-key")
+
+        mock_client = MagicMock(name="supabase_client")
+
+        def fake_create_client(_url, _key):
+            return mock_client
+
+        fake_mod = MagicMock()
+        fake_mod.create_client = fake_create_client
+        monkeypatch.setitem(sys.modules, "supabase", fake_mod)
+
+        manager.reset()
+        assert manager.get_client() is mock_client
+        svc = manager.get_user_data_service()
+        assert isinstance(svc, SupabaseUserDataService)
+        assert isinstance(svc, UserDataService)
+        assert svc._client is mock_client

--- a/tests/test_services/test_supabase_user_data_service.py
+++ b/tests/test_services/test_supabase_user_data_service.py
@@ -1,0 +1,79 @@
+"""
+SupabaseUserDataService のユニットテスト（Supabase クライアントは Mock）
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from services.gamification_constants import SIX_AXES
+from services.supabase_user_data_service import SupabaseUserDataService
+
+
+@pytest.fixture
+def mock_table():
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_client(mock_table):
+    c = MagicMock()
+    c.table.return_value = mock_table
+    return c
+
+
+class TestGetUserData:
+    def test_fetch_success_returns_db_payload(self, mock_client, mock_table):
+        stored = {"user_id": "u1", "skill_xp": {a: 10 for a in SIX_AXES}}
+        mock_table.select.return_value.eq.return_value.limit.return_value.execute.return_value = MagicMock(
+            data=[{"data": stored}]
+        )
+        svc = SupabaseUserDataService(mock_client)
+        out = svc.get_user_data("u1")
+        assert out == stored
+        mock_client.table.assert_called_with("user_data")
+
+    def test_unregistered_returns_default_structure(self, mock_client, mock_table):
+        mock_table.select.return_value.eq.return_value.limit.return_value.execute.return_value = MagicMock(data=[])
+        svc = SupabaseUserDataService(mock_client)
+        out = svc.get_user_data("new-user")
+        assert out["user_id"] == "new-user"
+        assert isinstance(out.get("skill_xp"), dict)
+        assert all(axis in out["skill_xp"] for axis in SIX_AXES)
+
+    def test_save_then_get_matches(self, mock_client, mock_table):
+        """UPSERT 後に同じ内容が select で返る想定"""
+        saved = {}
+
+        def upsert_exec():
+            row = mock_table.upsert.call_args[0][0]
+            saved["payload"] = row
+            return MagicMock()
+
+        def select_exec():
+            if "payload" not in saved:
+                return MagicMock(data=[])
+            d = saved["payload"]["data"]
+            return MagicMock(data=[{"data": d}])
+
+        mock_table.select.return_value.eq.return_value.limit.return_value.execute.side_effect = select_exec
+        mock_table.upsert.return_value.execute.side_effect = upsert_exec
+
+        svc = SupabaseUserDataService(mock_client)
+        default = svc.get_user_data("persist")
+        default["stats"] = default.get("stats") or {}
+        default["stats"]["total_scenarios_completed"] = 3
+
+        svc.save_user_data("persist", default)
+        got = svc.get_user_data("persist")
+        assert got["stats"]["total_scenarios_completed"] == 3
+
+
+class TestSaveUserData:
+    def test_rejects_none_data(self, mock_client):
+        svc = SupabaseUserDataService(mock_client)
+        with pytest.raises(TypeError, match="data must be a dict"):
+            svc.save_user_data("u1", None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- **DB統合**: SupabaseUserDataService（PostgreSQL永続化、JSONフォールバック）
- **認証**: Supabase Auth（メール/パスワード登録・ログイン）、ゲスト利用維持
- **会話永続化**: ConversationPersistenceService（保存・取得・検索）
- **マイグレーション**: 9テーブル + RLSポリシー（migrations/001_initial.sql）
- **切り替え**: UserDataFactory で環境変数ベースのDB/JSON切り替え
- **後方互換**: SUPABASE_URL未設定時は従来のJSON動作を維持

## Test plan

- [ ] Supabase関連テスト20件PASS
- [ ] 既存テスト395件に回帰なし
- [ ] SUPABASE_URL未設定時にJSONフォールバック動作
- [ ] /auth/login ページ表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cacc-lab/workplace-roleplay/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **New Features**
  * ユーザー認証機能（メール/パスワード登録・ログイン）を追加
  * 会話履歴の自動保存と検索機能を実装
  * ユーザーデータの永続化機能を提供

* **Documentation**
  * Supabase統合に関する設計・要件・実装計画ドキュメントを作成

* **Tests**
  * 認証・会話履歴・ユーザーデータサービスに関するテストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->