### PR TITLE
fix: Supabase public テーブルの RLS を有効化（server-side only）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,16 @@ ENABLE_LEARNING_HISTORY=false
 
 # 強み分析機能の有効化（true/false）
 ENABLE_STRENGTH_ANALYSIS=false
+
+# ========================================
+# Supabase 設定（オプション: DB永続化+匿名認証）
+# ========================================
+# SUPABASE_URL=https://xxxxx.supabase.co
+# SUPABASE_KEY=your_anon_public_key
+# SUPABASE_SERVICE_KEY=your_service_role_key
+#
+# セキュリティ:
+#   - public テーブル（user_data, conversations）は RLS 有効で anon/authenticated
+#     から完全に遮断されている（migrations/003_enable_rls_server_only.sql）
+#   - サーバーサイドは SUPABASE_SERVICE_KEY 経由で RLS をバイパスしてアクセスする
+#   - SUPABASE_SERVICE_KEY は絶対にフロントエンドに露出させないこと

--- a/.kiro/specs/supabase-rls-restore/bugfix.md
+++ b/.kiro/specs/supabase-rls-restore/bugfix.md
@@ -1,0 +1,60 @@
+# Bugfix: Supabase public テーブルの RLS 無効化を解消
+
+## Current Behavior（現在の動作）
+
+Supabase セキュリティアドバイザーから Critical 警告「`rls_disabled_in_public`」が通知された（2026-04-13 検出）。
+
+### 証拠
+
+**1. 対象テーブル**
+- `public.user_data` — `migrations/002_fix_rls.sql:17` で `DISABLE ROW LEVEL SECURITY`
+- `public.conversations` — `migrations/002_fix_rls.sql:36` で `DISABLE ROW LEVEL SECURITY`
+
+**2. 経緯**
+- `migrations/001_initial.sql` では全テーブルに RLS 有効 + `auth.uid() = user_id` ポリシー
+- `002_fix_rls.sql` で `user_id` を UUID → TEXT に変更（Flask サーバー側でユーザーID管理）
+- `auth.uid()` との突合が不可能になり、RLS 自体を無効化してしまった
+
+**3. リスク**
+- public テーブルが anon / authenticated ロールに対して無防備
+- Supabase プロジェクト URL と anon key が漏洩すると、全データの read/write/delete が可能
+- `services/supabase_client.py:76` は service_role key を優先使用するため、アプリ動作自体には影響しない
+
+## Expected Behavior（期待する動作）
+
+- `public.user_data` と `public.conversations` で RLS を **有効化**
+- anon / authenticated ロールには一切の権限を与えない（service_role のみアクセス可能）
+- service_role は RLS を自動バイパスするため、アプリは変更不要で今まで通り動作
+- Supabase セキュリティアドバイザーの Critical 警告が消える
+
+## Unchanged Behavior（変更しない動作）
+
+- `user_id` カラムの型（TEXT）は変更しない
+- アプリケーションコード（`services/supabase_client.py` 等）は変更しない
+- service_role key 経由の読み書きはすべて従来通り動作
+- 他テーブル（`skill_xp`, `xp_history` 等）の既存 RLS 設定は変更しない
+
+## Root Cause（根本原因）
+
+`002_fix_rls.sql` 作成時、`user_id` 型変更により auth.uid() ポリシーが無効化されることへの対応として、RLS 自体を無効化してしまった。正しくは「RLS 有効 + anon/authenticated に権限なし」とすべきだった（service_role は RLS をバイパスするため、サーバーサイドアクセスには影響しない）。
+
+## Fix Strategy（修正方針）
+
+新規マイグレーション `migrations/003_enable_rls_server_only.sql` を作成：
+
+1. `public.user_data` と `public.conversations` の RLS を `ENABLE`
+2. anon / authenticated ロールから `REVOKE ALL` で権限剥奪（念のため明示）
+3. ポリシーは作成しない（= service_role 以外はアクセス不可）
+4. Supabase Dashboard の SQL Editor で手動実行する手順を README 追記
+
+## Test Strategy（検証方法）
+
+1. マイグレーション適用後、Supabase Dashboard の Advisors で Critical 警告が消えることを確認
+2. アプリ起動後、ゲーミフィケーションの XP 保存・履歴取得が従来通り動作することを確認
+3. anon key で直接 `user_data` を SELECT してみて、`permission denied` または空配列が返ることを確認
+
+## Risk Assessment（リスク評価）
+
+- **破壊的変更**: なし（テーブル構造・データ・アプリコードすべて不変）
+- **ロールバック**: `ALTER TABLE ... DISABLE ROW LEVEL SECURITY` で即時復旧可能
+- **副作用**: anon key で直接アクセスするクライアント実装があれば動かなくなるが、現状は service_role のみの想定で問題なし

--- a/README.md
+++ b/README.md
@@ -191,7 +191,17 @@ DEFAULT_MODEL=gemini/gemini-2.5-flash-lite
 # Supabase（オプション: 設定するとDB永続化+匿名認証が有効）
 SUPABASE_URL=https://xxxxx.supabase.co
 SUPABASE_KEY=your_anon_public_key
+SUPABASE_SERVICE_KEY=your_service_role_key  # サーバーサイド用（RLSバイパス）
 ```
+
+### Supabase マイグレーション
+
+初回セットアップ時、および RLS ポリシー更新時は `migrations/` 配下の SQL を
+Supabase Dashboard → SQL Editor で番号順に実行する:
+
+1. `001_initial.sql` — 初期スキーマ
+2. `002_fix_rls.sql` — `user_id` を TEXT 化
+3. `003_enable_rls_server_only.sql` — public テーブルに RLS 有効化（service_role 経由のみアクセス可）
 
 ### 機能フラグ
 

--- a/migrations/003_enable_rls_server_only.sql
+++ b/migrations/003_enable_rls_server_only.sql
@@ -1,0 +1,32 @@
+-- 003: public.user_data / public.conversations の RLS を有効化（server-side only アクセス）
+--
+-- 背景:
+--   002_fix_rls.sql で user_id を TEXT 化した際に RLS を DISABLE してしまった。
+--   Supabase セキュリティアドバイザーが Critical「rls_disabled_in_public」を検出。
+--
+-- 方針:
+--   - RLS を ENABLE
+--   - ポリシーは作成しない（= anon / authenticated からのアクセスはすべて拒否）
+--   - service_role は RLS を自動バイパスするため、Flask サーバーサイドからの
+--     アクセス（services/supabase_client.py）は影響を受けない
+--
+-- ロールバック:
+--   ALTER TABLE public.user_data DISABLE ROW LEVEL SECURITY;
+--   ALTER TABLE public.conversations DISABLE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- user_data
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.user_data ENABLE ROW LEVEL SECURITY;
+
+-- 念のため anon / authenticated から明示的に権限剥奪
+REVOKE ALL ON public.user_data FROM anon;
+REVOKE ALL ON public.user_data FROM authenticated;
+
+-- ---------------------------------------------------------------------------
+-- conversations
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.conversations ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.conversations FROM anon;
+REVOKE ALL ON public.conversations FROM authenticated;


### PR DESCRIPTION
## Summary
- Supabase セキュリティアドバイザーの Critical 警告 `rls_disabled_in_public` を解消
- `public.user_data` / `public.conversations` に RLS を ENABLE し、anon/authenticated から REVOKE
- service_role は RLS をバイパスするため、Flask サーバーサイドのアクセスは影響なし

## 背景
`002_fix_rls.sql` で `user_id` を TEXT 化した際に `auth.uid()` ポリシーが使えなくなり、RLS 自体を DISABLE してしまっていた。anon key が漏洩すると public テーブルが丸見えになる状態だった。

## 変更ファイル
- \`migrations/003_enable_rls_server_only.sql\` (新規) — RLS 有効化 + REVOKE
- \`.kiro/specs/supabase-rls-restore/bugfix.md\` (新規) — Bugfix Spec
- \`README.md\` — マイグレーション適用手順追記
- \`.env.example\` — \`SUPABASE_SERVICE_KEY\` 追記

## 適用状況
- [x] Supabase Dashboard で SQL 実行済み
- [x] Supabase Advisors の Critical 警告消失を確認

## Test plan
- [x] Supabase Advisors で \`rls_disabled_in_public\` が解消していること
- [ ] アプリ起動後、XP 保存・履歴取得が従来通り動作することを確認
- [ ] anon key で直接 SELECT すると permission denied になること（任意）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cacc-lab/workplace-roleplay/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメンテーション
* Supabaseの初期設定手順とサーバーキー設定方法を追加
* 3つのデータベースマイグレーションの実行順序と内容をREADMEに記載

## バグ修正
* データベースのセキュリティ設定を改善し、アクセス制御を強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->