### PR TITLE
feat: Ollama Cloud 統合 (Phase A) — Gemma 4 31B Cloud を選択可能に

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,14 @@ ENABLE_LEARNING_HISTORY=false
 ENABLE_STRENGTH_ANALYSIS=false
 
 # ========================================
+# Ollama Cloud 設定（オプション: $20/月定額で高品質モデル利用）
+# ========================================
+# DEFAULT_MODEL=ollama/gemma4:31b-cloud に切替えることで有効化
+# APIキー発行: https://ollama.com/settings/keys
+# OLLAMA_API_KEY=your_ollama_api_key
+# OLLAMA_BASE_URL=https://ollama.com/v1  # デフォルト値（通常変更不要）
+
+# ========================================
 # Supabase 設定（オプション: DB永続化+匿名認証）
 # ========================================
 # SUPABASE_URL=https://xxxxx.supabase.co

--- a/.kiro/specs/ollama-cloud-integration/design.md
+++ b/.kiro/specs/ollama-cloud-integration/design.md
@@ -1,0 +1,95 @@
+# Ollama Cloud Integration — Design (Phase A)
+
+## アーキテクチャ概要
+
+Ollama Cloud は **OpenAI 互換 API** を提供する。`langchain-openai` の `ChatOpenAI` を `base_url=https://ollama.com/v1` で初期化すれば LangChain ライフサイクルに透過的に乗せられる。
+
+```
+LLMService.initialize_llm(model_name)
+├─ startswith("ollama/") → create_ollama_llm()  [NEW]
+│   └─ ChatOpenAI(base_url=OLLAMA_BASE_URL, api_key=OLLAMA_API_KEY, streaming=True)
+└─ それ以外                  → create_gemini_llm() [既存]
+    └─ ChatGoogleGenerativeAI(...)
+```
+
+## 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `requirements.txt` | `langchain-openai>=0.1.0,<1.0.0` 追加 |
+| `config/config.py` | `OLLAMA_API_KEY`, `OLLAMA_BASE_URL` フィールド追加 / `validate_model` に `ollama/*` パターン追加 |
+| `services/llm_service.py` | `create_ollama_llm()` 新設 / `initialize_llm()` 分岐 |
+| `.env.example` | Ollama 設定セクション追加 |
+| `README.md` | Ollama Cloud セットアップ手順追加 |
+
+## 実装詳細
+
+### `services/llm_service.py`
+
+```python
+from langchain_openai import ChatOpenAI  # NEW
+
+class LLMService:
+    OLLAMA_DEFAULT_BASE_URL = "https://ollama.com/v1"
+
+    def create_ollama_llm(self, model_name: str):
+        api_key = os.environ.get("OLLAMA_API_KEY", "").strip()
+        if not api_key:
+            raise RuntimeError(
+                "OLLAMA_API_KEY is not set. "
+                "Get one at https://ollama.com/settings/keys and add to .env"
+            )
+        base_url = os.environ.get("OLLAMA_BASE_URL", self.OLLAMA_DEFAULT_BASE_URL).strip()
+        return ChatOpenAI(
+            model=model_name,
+            api_key=api_key,
+            base_url=base_url,
+            temperature=self.default_temperature,
+            streaming=True,
+        )
+
+    def initialize_llm(self, model_name: str):
+        if model_name.startswith("ollama/"):
+            ollama_model = model_name.replace("ollama/", "", 1)
+            return self.create_ollama_llm(ollama_model)
+        # 既存 Gemini 経路
+        if model_name.startswith("gemini/"):
+            model_name = model_name.replace("gemini/", "", 1)
+        return self.create_gemini_llm(model_name)
+```
+
+### `config/config.py` の validate_model 拡張
+
+`ollama/<name>:<tag>` パターンを許可（例: `ollama/gemma4:31b-cloud`, `ollama/qwen2.5:72b-cloud`）。
+
+```python
+ollama_pattern = re.compile(r"^ollama/[a-z0-9_.\-]+(:[a-z0-9_.\-]+)?$")
+if ollama_pattern.match(v):
+    return v
+```
+
+`OLLAMA_API_KEY`, `OLLAMA_BASE_URL` は Optional フィールドとして追加（未設定でも Gemini 単独運用は継続可能）。
+
+## エラーハンドリング
+
+`what/why/how` 形式を踏襲：
+
+- **what**: `OLLAMA_API_KEY is not set`
+- **why**: Ollama Cloud モデル (`ollama/*`) の初期化には API キーが必須
+- **how**: https://ollama.com/settings/keys で発行し `.env` の `OLLAMA_API_KEY=` に設定
+
+## ストリーミング互換性
+
+`ChatOpenAI(streaming=True).astream()` は LangChain の `BaseChatModel` インターフェースで `ChatGoogleGenerativeAI` と同じ。`stream_chat_response()` 側は無変更で動作する。
+
+## テスト戦略
+
+1. **単体**: `create_ollama_llm()` のキー未設定時エラー、正常初期化、モデル名正規化
+2. **単体**: `initialize_llm()` の分岐（ollama/ prefix → ChatOpenAI 経路）
+3. **単体**: `validate_model` の `ollama/*` パターン許可
+4. **回帰**: 既存 Gemini 経路のテストが通ること
+5. **動作確認**: 実際に `OLLAMA_API_KEY` を設定してローカルで chat エンドポイント疎通
+
+## ロールバック
+
+`.env` の `DEFAULT_MODEL` を Gemini に戻すだけで完全ロールバック可能。コード変更は Gemini 経路を一切触らないため副作用なし。

--- a/.kiro/specs/ollama-cloud-integration/requirements.md
+++ b/.kiro/specs/ollama-cloud-integration/requirements.md
@@ -1,0 +1,40 @@
+# Ollama Cloud Integration — Requirements
+
+## 背景
+現状の `DEFAULT_MODEL=gemini-2.5-flash-lite` は AA Intelligence Index で平均以下の性能評価を受けており、シナリオロールプレイ/フィードバック生成用途では品質不足が懸念される。Ollama Cloud の `gemma4:31b-cloud`（MMLU 85.2%, GPQA 84.3%, 140言語対応, $20定額）は品質・予算可読性の両面で有力な選択肢。
+
+## スコープ（段階的導入）
+
+### Phase A（本Spec範囲）
+- **ミニマム統合**: Ollama Cloud を LLMService の追加プロバイダとして組み込む
+- `DEFAULT_MODEL=ollama/gemma4:31b-cloud` のように env で切替可能にする
+- 既存 Gemini 利用は一切変更しない
+- UI 変更なし
+
+### Phase B（本Spec範囲外・後続PR）
+- モード別モデル指定（SCENARIO_MODEL / CHAT_MODEL / FEEDBACK_MODEL）
+
+### Phase C（さらに後続）
+- UI でのモデル選択拡張
+
+## Functional Requirements
+
+1. **FR1**: `DEFAULT_MODEL=ollama/<model_name>` で Ollama Cloud モデルを指定可能
+2. **FR2**: `OLLAMA_API_KEY` 環境変数で Ollama Cloud 認証
+3. **FR3**: `OLLAMA_BASE_URL` でエンドポイント上書き可能（デフォルト: `https://ollama.com/v1`）
+4. **FR4**: ストリーミング応答（SSE）が従来どおり動作
+5. **FR5**: 既存の Gemini 分岐は完全に保持（`gemini/` or `gemini-` プレフィックス）
+6. **FR6**: `gemma4:31b-cloud` を少なくとも許可モデルリストに含める
+
+## Non-Functional Requirements
+
+1. **NFR1**: `OLLAMA_API_KEY` 未設定時は Ollama 系モデルの初期化で明確なエラーを返す
+2. **NFR2**: 既存テスト（1464 passed）を破壊しない
+3. **NFR3**: what/why/how 形式のエラーメッセージを保持
+
+## Out of Scope
+
+- モード別モデル指定（Phase B）
+- UI でのモデル選択拡張（Phase C）
+- Ollama local（`localhost:11434`）サポート — 必要になれば Phase C で検討
+- Anthropic / OpenAI 等、他プロバイダ全般の統合

--- a/.kiro/specs/ollama-cloud-integration/tasks.md
+++ b/.kiro/specs/ollama-cloud-integration/tasks.md
@@ -1,0 +1,21 @@
+# Ollama Cloud Integration — Tasks (Phase A)
+
+## Task List
+
+- [ ] T1. `requirements.txt` に `langchain-openai` 追加 + インストール
+- [ ] T2. `config/config.py` に `OLLAMA_API_KEY` / `OLLAMA_BASE_URL` フィールド追加
+- [ ] T3. `config/config.py` の `validate_model` に `ollama/*` パターン許可を追加
+- [ ] T4. `services/llm_service.py` に `create_ollama_llm()` を追加
+- [ ] T5. `services/llm_service.py` の `initialize_llm()` に ollama/ 分岐を追加
+- [ ] T6. `.env.example` に Ollama 設定セクション追加
+- [ ] T7. `README.md` に Ollama Cloud セットアップ手順追加
+- [ ] T8. 単体テスト追加（`tests/test_services/test_llm_service_ollama.py`）
+- [ ] T9. 既存テストが全件 PASS することを確認（1464 passed 維持）
+- [ ] T10. ローカルで `DEFAULT_MODEL=ollama/gemma4:31b-cloud` に切替えて動作確認
+- [ ] T11. commit + push + PR作成
+
+## 完了条件
+- Phase A の Functional Requirements (FR1-FR6) 全充足
+- 既存テスト 1464 passed 維持 + Ollama 経路の新規テスト追加
+- ローカルで Ollama Cloud 経由のチャット応答が返る
+- Gemini 運用も従来どおり動作（`DEFAULT_MODEL=gemini/...` でリグレッションなし）

--- a/README.md
+++ b/README.md
@@ -192,7 +192,32 @@ DEFAULT_MODEL=gemini/gemini-2.5-flash-lite
 SUPABASE_URL=https://xxxxx.supabase.co
 SUPABASE_KEY=your_anon_public_key
 SUPABASE_SERVICE_KEY=your_service_role_key  # サーバーサイド用（RLSバイパス）
+
+# Ollama Cloud（オプション: $20/月定額で高品質モデルを利用）
+# DEFAULT_MODEL=ollama/gemma4:31b-cloud
+# OLLAMA_API_KEY=your_ollama_api_key
+# OLLAMA_BASE_URL=https://ollama.com/v1
 ```
+
+### Ollama Cloud 連携
+
+Gemini の代わりに Ollama Cloud（OpenAI互換API）の高品質モデルを利用できる。
+料金は $20/月の定額プラン（Pro）で、サプライズ請求が発生しない利点がある。
+
+設定手順:
+
+1. https://ollama.com/settings/keys で API キーを発行
+2. `.env` に以下を設定
+   ```
+   OLLAMA_API_KEY=your_api_key_here
+   DEFAULT_MODEL=ollama/gemma4:31b-cloud
+   ```
+3. アプリ再起動
+
+利用可能モデル例（2026年4月時点）:
+- `ollama/gemma4:31b-cloud` — MMLU 85.2% / GPQA 84.3% / 140言語対応（推奨）
+- `ollama/qwen2.5:72b-cloud` — 高品質な日本語・コード対応
+- その他は https://ollama.com/search?c=cloud で確認
 
 ### Supabase マイグレーション
 

--- a/config/config.py
+++ b/config/config.py
@@ -26,6 +26,10 @@ class Config(BaseSettings):
     DEFAULT_MODEL: str = Field(default="gemini/gemini-1.5-flash", alias="DEFAULT_MODEL")
     API_BASE_URL: Optional[str] = Field(default=None, alias="API_BASE_URL")
 
+    # Ollama Cloud 設定（OpenAI互換API）
+    OLLAMA_API_KEY: Optional[str] = Field(default=None, alias="OLLAMA_API_KEY")
+    OLLAMA_BASE_URL: str = Field(default="https://ollama.com/v1", alias="OLLAMA_BASE_URL")
+
     # セッション設定
     SESSION_TYPE: str = Field(default="filesystem", alias="SESSION_TYPE")
     SESSION_LIFETIME_MINUTES: int = Field(default=30, alias="SESSION_LIFETIME_MINUTES")
@@ -116,6 +120,11 @@ class Config(BaseSettings):
         gemini_pattern = re.compile(r"^(gemini/)?gemini-\d+\.\d+-(pro|flash|flash-lite)(-.*)?$")
         if gemini_pattern.match(v):
             warnings.warn(f"Using experimental model pattern: {v}. Please verify compatibility.", UserWarning)
+            return v
+
+        # Ollama Cloud モデル: ollama/<name>[:<tag>] 形式（例: ollama/gemma4:31b-cloud）
+        ollama_pattern = re.compile(r"^ollama/[a-z0-9_.\-]+(:[a-z0-9_.\-]+)?$")
+        if ollama_pattern.match(v):
             return v
 
         raise ValueError(f"Unsupported model: {v}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ gevent>=23.0.0
 langchain>=0.1.0,<1.0.0
 langchain-core>=0.1.0,<1.0.0
 langchain-google-genai>=0.0.3
+langchain-openai>=0.1.0,<1.0.0  # Ollama Cloud (OpenAI互換API) 用
 google-generativeai>=0.3.0
 google-cloud-aiplatform>=1.36.0
 google-api-core>=2.15.0

--- a/services/llm_service.py
+++ b/services/llm_service.py
@@ -12,6 +12,11 @@ import google.generativeai as genai
 from langchain.schema import AIMessage, HumanMessage, SystemMessage
 from langchain_google_genai import ChatGoogleGenerativeAI
 
+try:  # Ollama Cloud は OpenAI 互換 API 経由で利用
+    from langchain_openai import ChatOpenAI  # type: ignore
+except ImportError:  # pragma: no cover - オプショナル依存
+    ChatOpenAI = None  # type: ignore
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from compliant_api_manager import CompliantAPIManager
 from config import Config
@@ -106,18 +111,66 @@ class LLMService:
             print(f"Error creating Gemini LLM: {str(e)}")
             raise
 
-    def initialize_llm(self, model_name: str) -> ChatGoogleGenerativeAI:
+    # Ollama Cloud のデフォルトエンドポイント（OpenAI互換API）
+    OLLAMA_DEFAULT_BASE_URL = "https://ollama.com/v1"
+
+    def create_ollama_llm(self, model_name: str):
         """
-        モデル名に基づいて適切なLLMを初期化
+        Ollama Cloud（OpenAI互換API）経由の LLM インスタンスを生成。
+
+        Args:
+            model_name: ollama/プレフィックスを除いたモデル名（例: "gemma4:31b-cloud"）
+
+        Returns:
+            ChatOpenAI: LangChain の ChatOpenAI インスタンス（base_url=Ollama Cloud）
+
+        Raises:
+            RuntimeError: langchain_openai 未インストール / OLLAMA_API_KEY 未設定
+        """
+        if ChatOpenAI is None:
+            raise RuntimeError(
+                "langchain-openai is not installed. "
+                "Install with: pip install langchain-openai"
+            )
+
+        api_key = (os.environ.get("OLLAMA_API_KEY") or "").strip()
+        if not api_key:
+            # what/why/how 形式のエラー
+            raise RuntimeError(
+                "OLLAMA_API_KEY is not set. "
+                "Ollama Cloud モデル (ollama/*) の初期化には API キーが必須です。 "
+                "https://ollama.com/settings/keys で発行し .env の OLLAMA_API_KEY に設定してください。"
+            )
+
+        base_url = (os.environ.get("OLLAMA_BASE_URL") or self.OLLAMA_DEFAULT_BASE_URL).strip()
+
+        return ChatOpenAI(
+            model=model_name,
+            api_key=api_key,
+            base_url=base_url,
+            temperature=self.default_temperature,
+            streaming=True,
+        )
+
+    def initialize_llm(self, model_name: str):
+        """
+        モデル名に基づいて適切なLLMを初期化（Gemini / Ollama Cloud を振り分け）
 
         Args:
             model_name: 使用するモデル名
+                - "gemini/..." / "gemini-..." → ChatGoogleGenerativeAI
+                - "ollama/..."                 → ChatOpenAI (Ollama Cloud)
 
         Returns:
-            ChatGoogleGenerativeAI: 初期化されたLLMインスタンス
+            LangChain BaseChatModel の具象インスタンス
         """
         try:
-            # gemini/プレフィックスを削除
+            # Ollama Cloud プレフィックス
+            if model_name.startswith("ollama/"):
+                ollama_model = model_name.replace("ollama/", "", 1)
+                return self.create_ollama_llm(ollama_model)
+
+            # Gemini 経路（既存）
             if model_name.startswith("gemini/"):
                 model_name = model_name.replace("gemini/", "")
 
@@ -126,7 +179,7 @@ class LLMService:
             print(f"Error in initialize_llm: {str(e)}")
             raise
 
-    def get_or_create_model(self, model_name: str) -> ChatGoogleGenerativeAI:
+    def get_or_create_model(self, model_name: str):
         """
         モデルを取得または作成（キャッシュ機能付き）
 
@@ -134,7 +187,7 @@ class LLMService:
             model_name: 使用するモデル名
 
         Returns:
-            ChatGoogleGenerativeAI: LLMインスタンス
+            LangChain BaseChatModel の具象インスタンス（Gemini / Ollama）
         """
         if model_name not in self.models:
             self.models[model_name] = self.initialize_llm(model_name)

--- a/tests/test_services/test_llm_service_ollama.py
+++ b/tests/test_services/test_llm_service_ollama.py
@@ -1,0 +1,108 @@
+"""
+LLMService の Ollama Cloud 経路テスト（Phase A）
+
+スコープ:
+- create_ollama_llm() のキー未設定時エラー
+- create_ollama_llm() の正常初期化
+- initialize_llm() の ollama/ 分岐
+- Gemini 経路のリグレッションが無いこと
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from services.llm_service import LLMService
+
+
+@pytest.fixture
+def service():
+    """GOOGLE_API_KEY が無くても初期化できるよう genai.configure をスキップ"""
+    with patch("services.llm_service.genai.configure"):
+        with patch("services.llm_service.CompliantAPIManager"):
+            yield LLMService()
+
+
+class TestCreateOllamaLlm:
+    def test_APIキー未設定でRuntimeErrorが発生する(self, service, monkeypatch):
+        monkeypatch.delenv("OLLAMA_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="OLLAMA_API_KEY"):
+            service.create_ollama_llm("gemma4:31b-cloud")
+
+    def test_APIキー設定時にChatOpenAIが生成される(self, service, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        with patch("services.llm_service.ChatOpenAI") as mock_chat:
+            mock_chat.return_value = MagicMock()
+            service.create_ollama_llm("gemma4:31b-cloud")
+            mock_chat.assert_called_once()
+            kwargs = mock_chat.call_args.kwargs
+            assert kwargs["model"] == "gemma4:31b-cloud"
+            assert kwargs["api_key"] == "test-key"
+            assert kwargs["base_url"] == "https://ollama.com/v1"
+            assert kwargs["streaming"] is True
+
+    def test_OLLAMA_BASE_URLで上書きできる(self, service, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+        monkeypatch.setenv("OLLAMA_BASE_URL", "https://custom.example.com/v1")
+        with patch("services.llm_service.ChatOpenAI") as mock_chat:
+            mock_chat.return_value = MagicMock()
+            service.create_ollama_llm("gemma4:31b-cloud")
+            assert mock_chat.call_args.kwargs["base_url"] == "https://custom.example.com/v1"
+
+    def test_langchain_openai未インストール時にRuntimeError(self, service, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+        with patch("services.llm_service.ChatOpenAI", None):
+            with pytest.raises(RuntimeError, match="langchain-openai"):
+                service.create_ollama_llm("gemma4:31b-cloud")
+
+
+class TestInitializeLlmRouting:
+    def test_ollamaプレフィックスでOllama経路に分岐する(self, service, monkeypatch):
+        monkeypatch.setenv("OLLAMA_API_KEY", "test-key")
+        with patch.object(service, "create_ollama_llm") as mock_ollama, \
+             patch.object(service, "create_gemini_llm") as mock_gemini:
+            mock_ollama.return_value = MagicMock()
+            service.initialize_llm("ollama/gemma4:31b-cloud")
+            mock_ollama.assert_called_once_with("gemma4:31b-cloud")
+            mock_gemini.assert_not_called()
+
+    def test_geminiプレフィックスでGemini経路に分岐する(self, service):
+        with patch.object(service, "create_ollama_llm") as mock_ollama, \
+             patch.object(service, "create_gemini_llm") as mock_gemini:
+            mock_gemini.return_value = MagicMock()
+            service.initialize_llm("gemini/gemini-2.5-flash")
+            mock_gemini.assert_called_once_with("gemini-2.5-flash")
+            mock_ollama.assert_not_called()
+
+    def test_プレフィックスなしでGemini経路に分岐する(self, service):
+        with patch.object(service, "create_ollama_llm") as mock_ollama, \
+             patch.object(service, "create_gemini_llm") as mock_gemini:
+            mock_gemini.return_value = MagicMock()
+            service.initialize_llm("gemini-2.5-flash-lite")
+            mock_gemini.assert_called_once_with("gemini-2.5-flash-lite")
+            mock_ollama.assert_not_called()
+
+
+class TestConfigValidateModel:
+    """config.Config の validate_model が ollama/* を受理することを確認"""
+
+    def test_ollama_gemma4が許可される(self):
+        from config.config import Config
+
+        cfg = Config(DEFAULT_MODEL="ollama/gemma4:31b-cloud")
+        assert cfg.DEFAULT_MODEL == "ollama/gemma4:31b-cloud"
+
+    def test_ollama_qwen2_5が許可される(self):
+        from config.config import Config
+
+        cfg = Config(DEFAULT_MODEL="ollama/qwen2.5:72b-cloud")
+        assert cfg.DEFAULT_MODEL == "ollama/qwen2.5:72b-cloud"
+
+    def test_未サポートプロバイダは拒否される(self):
+        from config.config import Config
+
+        with pytest.raises(ValueError, match="Unsupported model"):
+            Config(DEFAULT_MODEL="anthropic/claude-3-opus")


### PR DESCRIPTION
## Summary
- LLMService に Ollama Cloud（OpenAI互換API）プロバイダを追加
- \`DEFAULT_MODEL=ollama/gemma4:31b-cloud\` のように env で切替可能
- 既存 Gemini 経路は完全保持、リグレッションなし
- Phase A（ミニマム統合）スコープ。Phase B（モード別モデル指定）は後続 PR

## 背景
現行 \`gemini-2.5-flash-lite\` は AA Intelligence Index で平均以下評価。Gemma 4 31B Cloud は MMLU 85.2% / GPQA 84.3% / 140言語対応、$20/月定額でサプライズ請求なし。

## 変更
| ファイル | 内容 |
|---|---|
| \`requirements.txt\` | \`langchain-openai\` 追加 |
| \`config/config.py\` | \`OLLAMA_API_KEY\`/\`OLLAMA_BASE_URL\` + \`ollama/*\` 許可 |
| \`services/llm_service.py\` | \`create_ollama_llm()\` 新設 + 振り分け |
| \`.env.example\` / \`README.md\` | セットアップ手順 |
| \`tests/.../test_llm_service_ollama.py\` | 10 tests 追加 |
| \`.kiro/specs/ollama-cloud-integration/\` | requirements/design/tasks |

## 動作確認（ローカル実施済）
- [x] \`ChatOpenAI\` 経由で Ollama Cloud Gemma 4 31B 接続成功
- [x] 日本語 \`invoke()\` / \`stream()\` 動作確認
- [x] 上司役ロールプレイで品質確認（3段階の使い分け）
- [x] Flask アプリ起動 → \`/api/models\` に反映確認
- [x] 既存 1473 passed + 新規 10 passed（リグレッションなし）

## デプロイ時の注意
マージしてもアプリ動作は変わりません（\`DEFAULT_MODEL\` を切替えるまで Gemini 経路）。本番で有効化する場合は:
1. 本番 VM の \`.env.production\` に \`OLLAMA_API_KEY\` を追加
2. \`DEFAULT_MODEL=ollama/gemma4:31b-cloud\` に変更
3. systemctl restart

## Test plan
- [ ] CI（ユニットテスト）の pass
- [ ] main マージ後、本番ヘルスチェック 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cacc-lab/workplace-roleplay/pull/43" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Ollama Cloudサービスの統合機能を追加しました。Gemini以外のモデルをデフォルトモデルとして選択・利用できるようになります。

* **ドキュメント**
  * Ollama Cloudの接続設定ガイドをREADMEに追加しました。設定手順と利用可能なモデル情報を記載しています。

* **テスト**
  * 新機能の動作確認テストを追加しました。

* **その他**
  * 統合に必要なライブラリ依存関係を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->