### PR TITLE
ci: 本番デプロイに Ollama / モード別モデル Secrets 追加

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -149,7 +149,17 @@ jobs:
             echo '' >> ${{ env.APP_PATH }}/.env
             echo 'SUPABASE_URL=${{ secrets.SUPABASE_URL }}' >> ${{ env.APP_PATH }}/.env
             echo 'SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}' >> ${{ env.APP_PATH }}/.env
-            
+            echo 'SUPABASE_SERVICE_KEY=${{ secrets.SUPABASE_SERVICE_KEY }}' >> ${{ env.APP_PATH }}/.env
+
+            # Append Ollama Cloud credentials and mode-specific models from GitHub Secrets
+            # 未設定の Secrets は空文字列として追記されるが、空値は resolve_model / config 側で
+            # 適切にスキップされ、DEFAULT_MODEL にフォールバックする
+            echo 'OLLAMA_API_KEY=${{ secrets.OLLAMA_API_KEY }}' >> ${{ env.APP_PATH }}/.env
+            echo 'SCENARIO_MODEL=${{ secrets.SCENARIO_MODEL }}' >> ${{ env.APP_PATH }}/.env
+            echo 'FEEDBACK_MODEL=${{ secrets.FEEDBACK_MODEL }}' >> ${{ env.APP_PATH }}/.env
+            echo 'CHAT_MODEL=${{ secrets.CHAT_MODEL }}' >> ${{ env.APP_PATH }}/.env
+            echo 'WATCH_MODEL=${{ secrets.WATCH_MODEL }}' >> ${{ env.APP_PATH }}/.env
+
             # Restart application service
             sudo systemctl restart ${{ env.SERVICE_NAME }}
             sleep 5

--- a/config/config.py
+++ b/config/config.py
@@ -92,10 +92,11 @@ class Config(BaseSettings):
     @field_validator("DEFAULT_MODEL", "SCENARIO_MODEL", "CHAT_MODEL", "WATCH_MODEL", "FEEDBACK_MODEL")
     def validate_model(cls, v):
         """モデル名のバリデーション（動的パターンマッチング対応）。
-        モード別フィールド（SCENARIO_MODEL 等）は None 許可。"""
-        # モード別モデルは未設定 (None) を許可（DEFAULT_MODEL にフォールバック）
-        if v is None:
-            return v
+        モード別フィールド（SCENARIO_MODEL 等）は None / 空文字列を許可。"""
+        # モード別モデルは未設定 (None / "") を許可（DEFAULT_MODEL にフォールバック）
+        # 空文字列は GitHub Secrets が未設定のとき "KEY=" で書き込まれた場合に発生
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return None
         import re
 
         # サポートされているモデルの明示的リスト（2024年12月最新）

--- a/tests/test_services/test_model_selector.py
+++ b/tests/test_services/test_model_selector.py
@@ -90,3 +90,14 @@ class TestConfigModeFields:
 
         with pytest.raises(ValueError, match="Unsupported model"):
             Config(FEEDBACK_MODEL="invalid/random-model")
+
+    def test_空文字列はNoneとして扱われる(self, monkeypatch):
+        """GitHub Secrets 未設定時に '.env' へ 'KEY=' が書き込まれるケース"""
+        from config.config import Config
+
+        for key in ("SCENARIO_MODEL", "CHAT_MODEL", "WATCH_MODEL", "FEEDBACK_MODEL"):
+            monkeypatch.delenv(key, raising=False)
+
+        cfg = Config(_env_file=None, SCENARIO_MODEL="", CHAT_MODEL="   ")
+        assert cfg.SCENARIO_MODEL is None
+        assert cfg.CHAT_MODEL is None


### PR DESCRIPTION
## Summary
本番デプロイ時に \`.env\` へ Ollama Cloud / モード別モデル設定を Secrets から書き込む。SSH不要で本番反映が可能に。

## マージ前に必要な作業（GitHub UI で Secrets 登録）

**https://github.com/CaCC-Lab/workplace-roleplay/settings/secrets/actions** で以下を登録:

| Secret 名 | 値 |
|---|---|
| \`OLLAMA_API_KEY\` | \`4856a1d08f274f7d9c9bac7a1c4c63f5.HMhygHhozFws2qbHMIACTyZQ\` |
| \`SCENARIO_MODEL\` | \`ollama/gemma4:31b-cloud\` |
| \`FEEDBACK_MODEL\` | \`ollama/gemma4:31b-cloud\` |

段階的適用推奨のため、\`CHAT_MODEL\` / \`WATCH_MODEL\` は未登録のままでOK（DEFAULT_MODELにフォールバック）。

## 変更
- \`.github/workflows/deploy-production.yml\`: echo 行追加
- \`config/config.py\`: 空文字列を None 扱いに（未登録 Secrets 対応）
- \`tests/...test_model_selector.py\`: 空文字列ケースのテスト追加

## マージ→本番反映の流れ
1. Secrets 登録
2. 本PRマージ → GitHub Actions が自動デプロイ
3. 本番で Ollama Cloud が有効化される
4. ヘルスチェック & 実利用で動作確認

## Test plan
- [ ] Secrets 3件登録
- [ ] マージ後のデプロイワークフロー成功
- [ ] 本番ヘルスチェック 200
- [ ] 本番でシナリオを実行、AI応答品質向上を体感

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cacc-lab/workplace-roleplay/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
