### PR TITLE
fix: フロントが DEFAULT_MODEL を localStorage に自動保存し <MODE>_MODEL env を無効化するバグ修正

### DIFF
--- a/.kiro/specs/feedback-model-override/bugfix.md
+++ b/.kiro/specs/feedback-model-override/bugfix.md
@@ -1,0 +1,88 @@
+# Bugfix: フロントエンドが DEFAULT_MODEL を勝手に送信し FEEDBACK_MODEL を無視する
+
+## Current Behavior（現在の動作）
+
+本番では `FEEDBACK_MODEL=ollama/gemma4:31b-cloud` を設定しているが、シナリオのフィードバック画面右下に「使用モデル: gemini/gemini-2.5-flash-lite」と表示される。つまり **Ollama Gemma 4 が使われず Gemini Flash Lite が使われている**。
+
+### 証拠
+
+1. `static/js/model-selection.js:28`
+   ```javascript
+   if (!flags.model_selection && flags.default_model) {
+       localStorage.setItem('selectedModel', flags.default_model);
+   }
+   ```
+   → モデル選択UI無効時に DEFAULT_MODEL を自動で localStorage に書き込む
+
+2. `static/js/model-selection.js:89`, `chat.js:35, 107, 258`, `scenario.js:114`
+   → 同様のパターンで DEFAULT_MODEL を localStorage に自動保存
+
+3. `static/js/scenario.js:296`
+   ```javascript
+   body: JSON.stringify({
+       scenario_id: scenarioId,
+       model: selectedModel  // localStorage から取得した DEFAULT_MODEL が送信される
+   })
+   ```
+
+4. バックエンド `routes/scenario_routes.py`
+   ```python
+   selected_model = resolve_model("feedback", data.get("model"))
+   ```
+   `resolve_model()` は第2引数 (session_selected) を最優先するため、
+   フロントが送った DEFAULT_MODEL が FEEDBACK_MODEL env よりも優先されてしまう。
+
+## Expected Behavior（期待する動作）
+
+**ユーザーが明示的にモデルを選択した場合のみ** `model` を送信する。
+何も選んでいない場合は `model` を省略（または `null`）→ バックエンドが
+`<MODE>_MODEL` env → `DEFAULT_MODEL` の順でフォールバック。
+
+結果、`FEEDBACK_MODEL=ollama/gemma4:31b-cloud` が正しく効く。
+
+## Unchanged Behavior（変更しない動作）
+
+- モデル選択UIを有効にしている場合（ユーザーが明示的に選んだ場合）の挙動は不変
+- バックエンドの `resolve_model()` ロジックは変更しない
+- Gemini単独運用時（FEEDBACK_MODEL未設定）の動作は不変
+
+## Root Cause（根本原因）
+
+フロント側が「localStorage が空なら DEFAULT_MODEL を書き込む」というフォールバックロジックを持っており、その結果、**ユーザーが実際に選択していないモデル**がバックエンドに「UI選択」として送信されていた。これが Phase B で導入した `<MODE>_MODEL` env を上書きしてしまう。
+
+## Fix Strategy（修正方針）
+
+1. **モデル選択UI無効時は localStorage を能動的にクリア**
+   - 既存ユーザーのブラウザに残った旧 DEFAULT_MODEL 値を除去するため
+   - `model-selection.js` の `!flags.model_selection` 分岐を `setItem` → `removeItem` に変更
+
+2. **各所の "デフォルトを localStorage に書き込む" 処理を削除**
+   - `chat.js` / `scenario.js` / `model-selection.js` の該当箇所
+   - 代わりにローカル変数で `window.DEFAULT_MODEL` をフォールバック利用するだけに留める
+
+3. **ユーザーが `<select>` を明示変更した場合の保存は維持**（`addEventListener('change', ...)`）
+
+### 修正対象
+
+| ファイル | 行 | 修正 |
+|---|---|---|
+| `static/js/model-selection.js` | 27-29 | `setItem` → `removeItem`（旧値クリア） |
+| `static/js/model-selection.js` | 87-90 | 削除（/api/models 取得後の自動保存を廃止） |
+| `static/js/chat.js` | 33-37, 104-109, 256-259 | `localStorage.setItem` 行を削除 |
+| `static/js/scenario.js` | 111-116 | `localStorage.setItem` 行を削除 |
+
+修正後、`localStorage.getItem('selectedModel')` の結果は:
+- ユーザー明示選択あり: 選択値
+- それ以外: `null` → フロントは `model: null` 送信 → バックエンドが env/DEFAULT にフォールバック
+
+## Test Strategy
+
+- **手動**: 本番反映後、シナリオ実行 → フィードバック取得 → 右下の「使用モデル」が `ollama/gemma4:31b-cloud` に変わること
+- **コード**: `localStorage.getItem` の null チェック後、`setItem` 呼び出しが無いこと
+- **回帰**: モデル選択UI有効時に `<select>` 変更で保存される動作は従来どおり
+
+## Risk Assessment
+
+- **破壊的変更**: なし（localStorage を空にしてもバックエンドがフォールバックするため）
+- **ロールバック**: revert で即戻る
+- **副作用**: 既存ユーザーの localStorage に値が残っている場合は依然として送信される → 影響は「一度サイトを開いたユーザーでは依然バグる」。完全解消には localStorage.removeItem('selectedModel') を入れるか、送信側で無効化する

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -28,13 +28,8 @@ async function getCSRFToken() {
 async function startConversation() {
     if (conversationStarted) return;
 
-    let selectedModel = localStorage.getItem('selectedModel');
-    if (!selectedModel) {
-        // デフォルトモデルを設定
-        selectedModel = window.DEFAULT_MODEL || 'gemini-1.5-flash';
-        localStorage.setItem('selectedModel', selectedModel);
-        console.log('デフォルトモデルを設定:', selectedModel);
-    }
+    // ユーザーが明示的に選択したモデル（無ければ null を送りバックエンドのフォールバックに委譲）
+    const selectedModel = localStorage.getItem('selectedModel');
 
     const partnerType = document.getElementById('partner-type').value;
     const situation = document.getElementById('situation').value;
@@ -100,13 +95,8 @@ async function sendMessage() {
     messageInput.disabled = true;
     sendButton.disabled = true;
 
-    let selectedModel = localStorage.getItem('selectedModel');
-    if (!selectedModel) {
-        // デフォルトモデルを設定
-        selectedModel = window.DEFAULT_MODEL || 'gemini-1.5-flash';
-        localStorage.setItem('selectedModel', selectedModel);
-        console.log('デフォルトモデルを設定:', selectedModel);
-    }
+    // ユーザーが明示的に選択したモデル（未選択なら null → バックエンドの resolve_model にフォールバック）
+    const selectedModel = localStorage.getItem('selectedModel');
 
     displayMessage("あなた: " + msg, "user-message");
     messageInput.value = "";
@@ -252,11 +242,7 @@ async function getFeedback() {
 // 履歴クリア処理
 async function clearHistory() {
     try {
-        let selectedModel = localStorage.getItem('selectedModel');
-        if (!selectedModel) {
-            selectedModel = window.DEFAULT_MODEL || 'gemini-1.5-flash';
-            localStorage.setItem('selectedModel', selectedModel);
-        }
+        const selectedModel = localStorage.getItem('selectedModel');
         // CSRFトークンを取得
         const token = await getCSRFToken();
         

--- a/static/js/model-selection.js
+++ b/static/js/model-selection.js
@@ -23,9 +23,13 @@ document.addEventListener('DOMContentLoaded', function() {
                 strengthAnalysisCard.style.display = 'block';
             }
             
-            // モデル選択が無効の場合はデフォルトモデルを使用
-            if (!flags.model_selection && flags.default_model) {
-                localStorage.setItem('selectedModel', flags.default_model);
+            // モデル選択UIが無効の場合は localStorage の旧キャッシュを除去。
+            // （localStorage に DEFAULT_MODEL を書き込むと、フィードバック/シナリオ時に
+            //  `model` として送信されてしまい、バックエンドの <MODE>_MODEL env を
+            //  上書きしてしまうため。
+            //  未設定 (null) で送信し、バックエンドの resolve_model にフォールバックを委譲する）
+            if (!flags.model_selection) {
+                localStorage.removeItem('selectedModel');
             }
         })
         .catch(err => {
@@ -84,10 +88,8 @@ document.addEventListener('DOMContentLoaded', function() {
                         modelSelect.value = geminiModels[0].value;
                     }
                     
-                    // 選択を保存
-                    if (modelSelect.value) {
-                        localStorage.setItem('selectedModel', modelSelect.value);
-                    }
+                    // ユーザーが明示的に選択を変更したときのみ保存するため、
+                    // ここでの自動保存は行わない（<select> の change ハンドラで保存される）
                 }
             }
         })

--- a/static/js/scenario.js
+++ b/static/js/scenario.js
@@ -32,11 +32,8 @@ async function sendMessage() {
     const msg = messageInput.value.trim();
     if (!msg) return;
 
+    // localStorage に明示選択がなければ null を送信 → バックエンドの resolve_model に委譲
     const selectedModel = localStorage.getItem('selectedModel');
-    if (!selectedModel) {
-        displayMessage("エラー: モデルが選択されていません。トップページでモデルを選択してください。", "error-message");
-        return;
-    }
 
     displayMessage("あなた: " + msg, "user-message");
     messageInput.value = "";  // 入力欄をクリア
@@ -106,14 +103,9 @@ window.addEventListener('beforeunload', function(e) {
 // 初期メッセージの取得
 window.addEventListener('load', async () => {
     try {
-        // モデル選択（localStorageから取得、なければデフォルト値を使用）
-        let selectedModel = localStorage.getItem('selectedModel');
-        if (!selectedModel) {
-            // デフォルトモデルを設定（gemini-1.5-flashをデフォルトとする）
-            selectedModel = window.DEFAULT_MODEL || 'gemini-1.5-flash';
-            localStorage.setItem('selectedModel', selectedModel);
-            console.log('デフォルトモデルを設定:', selectedModel);
-        }
+        // ユーザーが明示的に選択したモデル（未選択なら null を送信し、バックエンドの
+        // resolve_model("scenario", ...) が SCENARIO_MODEL env → DEFAULT_MODEL にフォールバック）
+        const selectedModel = localStorage.getItem('selectedModel');
         
         // CSRFトークンを取得
         const token = await getCSRFToken();
@@ -883,7 +875,16 @@ document.addEventListener('DOMContentLoaded', function() {
 // 2. モデル未選択時の対応強化
 function validateModelSelection() {
     const selectedModel = localStorage.getItem('selectedModel');
-    
+
+    // モデル選択UIが無効（機能フラグで非表示）の場合は検証をスキップ。
+    // バックエンドの resolve_model が <MODE>_MODEL env → DEFAULT_MODEL で自動解決する。
+    const modelSelectionSection = document.getElementById('model-selection-section');
+    const isModelSelectionVisible =
+        modelSelectionSection && modelSelectionSection.style.display !== 'none';
+    if (!isModelSelectionVisible) {
+        return true;
+    }
+
     if (!selectedModel) {
         // モデルが選択されていない場合
         const errorDiv = document.createElement('div');

--- a/static/js/watch.js
+++ b/static/js/watch.js
@@ -69,11 +69,9 @@ speedSlider.addEventListener('change', function() {
 // 観戦開始
 startButton.addEventListener('click', async function() {
     if (!conversationStarted) {
+        // ユーザーが明示的に選択していなければ null を送信 → バックエンドの
+        // resolve_model("watch", ...) が WATCH_MODEL env → DEFAULT_MODEL でフォールバック
         const selectedModel = localStorage.getItem('selectedModel');
-        if (!selectedModel) {
-            displayMessage("エラー: モデルが選択されていません。トップページでモデルを選択してください。", "error-message");
-            return;
-        }
 
         const partnerType = document.getElementById('partner-type').value;
         const situation = document.getElementById('situation').value;


### PR DESCRIPTION
## Summary
フィードバック画面右下の「使用モデル: gemini/gemini-2.5-flash-lite」表示（および Gemini レート制限 hit）の原因修正。

## 症状
本番で \`FEEDBACK_MODEL=ollama/gemma4:31b-cloud\` / \`SCENARIO_MODEL=ollama/qwen3.5:397b-cloud\` を設定しても、実際は Gemini が使われていた。

## 原因
フロント側が localStorage に selectedModel が無い時に DEFAULT_MODEL を自動書き込みしており、それが API リクエストの \`model\` として送信され、バックエンドの \`resolve_model()\` が session_selected 扱いで最優先してしまっていた。

## 修正
- \`model-selection.js\`: モデル選択UI無効時は localStorage.removeItem（旧値クリア）
- \`chat.js\` / \`scenario.js\` / \`watch.js\` / \`model-selection.js\`: デフォルト自動保存処理を削除
- \`scenario.js\` / \`watch.js\`: localStorage 未設定時のブロック処理を削除
- \`validateModelSelection()\`: UI非表示時は検証スキップ

## Test plan
- [x] 既存 1487 tests PASS
- [ ] マージ後に本番で：
  - シナリオでロールプレイ開始 → Ollama Qwen 397B で応答（Geminiレート制限が出ない）
  - フィードバック取得 → 右下に「使用モデル: ollama/gemma4:31b-cloud」表示

Spec: \`.kiro/specs/feedback-model-override/bugfix.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cacc-lab/workplace-roleplay/pull/47" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
- モデル選択時の処理を改善しました。ユーザーが明示的に選択した場合のみ選択内容を保持し、デフォルト値による不正な上書きを防ぐようにしました。モデル選択UIが無効な場合は保存済みデータをクリアするようになります。これにより、バックエンド側のモデル設定が正しく機能するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->