### PR TITLE
fix: DEFAULT_MODEL を GitHub Secrets から上書き可能にする

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -163,6 +163,12 @@ jobs:
             echo 'SUPABASE_KEY=${{ secrets.SUPABASE_KEY }}' >> ${{ env.APP_PATH }}/.env
             echo 'SUPABASE_SERVICE_KEY=${{ secrets.SUPABASE_SERVICE_KEY }}' >> ${{ env.APP_PATH }}/.env
 
+            # DEFAULT_MODEL を Secrets から上書き（設定されていれば .env.production の値を上書き）
+            if [ -n '${{ secrets.DEFAULT_MODEL }}' ]; then
+              sed -i '/^DEFAULT_MODEL=/d' ${{ env.APP_PATH }}/.env
+              echo 'DEFAULT_MODEL=${{ secrets.DEFAULT_MODEL }}' >> ${{ env.APP_PATH }}/.env
+            fi
+
             # Append Ollama Cloud credentials and mode-specific models from GitHub Secrets
             # 未設定の Secrets は空文字列として追記されるが、空値は resolve_model / config 側で
             # 適切にスキップされ、DEFAULT_MODEL にフォールバックする


### PR DESCRIPTION
## Summary
デプロイ時に \`DEFAULT_MODEL\` を GitHub Secrets から上書き可能にする。
SSH不要で DEFAULT_MODEL を変更できる。

## 背景
Gemini 2.5 Flash Lite の品質が不十分なため、DEFAULT_MODEL を \`ollama/gemma4:31b-cloud\` に全統一したいが、既存ワークフローに DEFAULT_MODEL の上書き機構がなかった。

## マージ前に Secret 登録

https://github.com/CaCC-Lab/workplace-roleplay/settings/secrets/actions

| Secret 名 | 値 |
|---|---|
| \`DEFAULT_MODEL\` | \`ollama/gemma4:31b-cloud\` |

## Test plan
- [ ] Secret 登録
- [ ] マージ後デプロイ成功
- [ ] 全モード Ollama Gemma 4 31B で動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cacc-lab/workplace-roleplay/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チューアス (Chores)**
  * 本番環境デプロイメントプロセスを更新しました。GitHubシークレットを使用してデフォルトモデル設定を動的に構成できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->