### PR TITLE
fix: 雑談開始時にシステムプロンプト未送信でメタ解説が出るバグ修正

### DIFF
--- a/routes/chat_routes.py
+++ b/routes/chat_routes.py
@@ -200,20 +200,19 @@ def start_chat() -> Response:
         }
         session.modified = True
 
-        # 初回メッセージの生成
-        first_prompt = f"""
-相手: {get_partner_description(partner_type)}
-状況: {get_situation_description(situation)}
-話題: {get_topic_description(topic)}
-
-上記の設定で、あなたから雑談を始めてください。
-最初の声かけとして、状況に応じた自然な挨拶や話題提供をしてください。
-"""
+        # 初回メッセージの生成（システムプロンプトを含めて送信）
+        system_prompt = session["chat_settings"]["system_prompt"]
+        first_user_msg = "上記の設定で、あなたから雑談を始めてください。最初の声かけとして、状況に応じた自然な挨拶や話題提供をしてください。"
 
         try:
-            from app import create_model_and_get_response
+            from app import initialize_llm, extract_content
 
-            response = create_model_and_get_response(model_name, first_prompt)
+            llm = initialize_llm(model_name)
+            messages = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=first_user_msg),
+            ]
+            response = extract_content(llm.invoke(messages))
 
             # 履歴に保存
             add_to_session_history("chat_history", {"human": "[雑談開始]", "ai": response})

--- a/tests/test_routes/test_chat_routes.py
+++ b/tests/test_routes/test_chat_routes.py
@@ -69,8 +69,9 @@ class TestStartChat:
 
     def test_雑談開始が正常に動作する(self, csrf_client):
         """雑談を正常に開始できること"""
-        with patch("app.create_model_and_get_response") as mock_create:
-            mock_create.return_value = "おはようございます！今日もお仕事お疲れ様です。"
+        with patch("app.initialize_llm") as mock_llm, patch("app.extract_content") as mock_extract:
+            mock_llm.return_value.invoke.return_value = "おはようございます！今日もお仕事お疲れ様です。"
+            mock_extract.return_value = "おはようございます！今日もお仕事お疲れ様です。"
 
             response = csrf_client.post(
                 "/api/start_chat",
@@ -91,8 +92,9 @@ class TestStartChat:
         partner_types = ["colleague", "senior", "junior", "boss", "client"]
 
         for partner_type in partner_types:
-            with patch("app.create_model_and_get_response") as mock_create:
-                mock_create.return_value = "テスト応答"
+            with patch("app.initialize_llm") as mock_llm, patch("app.extract_content") as mock_extract:
+                mock_llm.return_value.invoke.return_value = "テスト応答"
+                mock_extract.return_value = "テスト応答"
 
                 response = csrf_client.post(
                     "/api/start_chat",
@@ -111,8 +113,9 @@ class TestStartChat:
         situations = ["break", "lunch", "morning", "evening", "party"]
 
         for situation in situations:
-            with patch("app.create_model_and_get_response") as mock_create:
-                mock_create.return_value = "テスト応答"
+            with patch("app.initialize_llm") as mock_llm, patch("app.extract_content") as mock_extract:
+                mock_llm.return_value.invoke.return_value = "テスト応答"
+                mock_extract.return_value = "テスト応答"
 
                 response = csrf_client.post(
                     "/api/start_chat",
@@ -131,8 +134,9 @@ class TestStartChat:
         topics = ["general", "hobby", "news", "food", "work"]
 
         for topic in topics:
-            with patch("app.create_model_and_get_response") as mock_create:
-                mock_create.return_value = "テスト応答"
+            with patch("app.initialize_llm") as mock_llm, patch("app.extract_content") as mock_extract:
+                mock_llm.return_value.invoke.return_value = "テスト応答"
+                mock_extract.return_value = "テスト応答"
 
                 response = csrf_client.post(
                     "/api/start_chat",
@@ -148,8 +152,8 @@ class TestStartChat:
 
     def test_レート制限エラーを適切に処理する(self, csrf_client):
         """レート制限エラーが発生した場合"""
-        with patch("app.create_model_and_get_response") as mock_create:
-            mock_create.side_effect = Exception("429 Resource has been exhausted")
+        with patch("app.initialize_llm") as mock_llm:
+            mock_llm.return_value.invoke.side_effect = Exception("429 Resource has been exhausted")
 
             response = csrf_client.post(
                 "/api/start_chat",

--- a/tests/test_routes/test_chat_routes_extended.py
+++ b/tests/test_routes/test_chat_routes_extended.py
@@ -111,8 +111,9 @@ class TestStartChat:
 
     def test_正常な開始(self, client):
         """正常な雑談開始"""
-        with patch("app.create_model_and_get_response") as mock_response:
-            mock_response.return_value = "こんにちは！いい天気ですね。"
+        with patch("app.initialize_llm") as mock_llm, patch("app.extract_content") as mock_extract:
+            mock_llm.return_value.invoke.return_value = "こんにちは！いい天気ですね。"
+            mock_extract.return_value = "こんにちは！いい天気ですね。"
 
             response = client.post(
                 "/api/start_chat",
@@ -130,8 +131,8 @@ class TestStartChat:
 
     def test_レート制限エラー(self, client):
         """レート制限エラー発生"""
-        with patch("app.create_model_and_get_response") as mock_response:
-            mock_response.side_effect = Exception("Rate limit exceeded")
+        with patch("app.initialize_llm") as mock_llm:
+            mock_llm.return_value.invoke.side_effect = Exception("Rate limit exceeded")
 
             with patch("errors.handle_llm_specific_error") as mock_handler:
                 from errors import RateLimitError
@@ -153,8 +154,8 @@ class TestStartChat:
 
     def test_一般エラー(self, client):
         """一般エラー発生"""
-        with patch("app.create_model_and_get_response") as mock_response:
-            mock_response.side_effect = Exception("API error")
+        with patch("app.initialize_llm") as mock_llm:
+            mock_llm.return_value.invoke.side_effect = Exception("API error")
 
             with patch("errors.handle_llm_specific_error") as mock_handler:
                 from errors import ExternalAPIError
@@ -274,8 +275,9 @@ class TestPartnerTypeDescriptions:
         partner_types = ["colleague", "senior", "junior", "manager", "client"]
 
         for partner_type in partner_types:
-            with patch("app.create_model_and_get_response") as mock_response:
-                mock_response.return_value = "テスト応答"
+            with patch("app.initialize_llm") as mock_llm, patch("app.extract_content") as mock_extract:
+                mock_llm.return_value.invoke.return_value = "テスト応答"
+                mock_extract.return_value = "テスト応答"
 
                 response = client.post(
                     "/api/start_chat",
@@ -296,8 +298,9 @@ class TestSituationDescriptions:
         situations = ["break", "lunch", "meeting", "after_work"]
 
         for situation in situations:
-            with patch("app.create_model_and_get_response") as mock_response:
-                mock_response.return_value = "テスト応答"
+            with patch("app.initialize_llm") as mock_llm, patch("app.extract_content") as mock_extract:
+                mock_llm.return_value.invoke.return_value = "テスト応答"
+                mock_extract.return_value = "テスト応答"
 
                 response = client.post(
                     "/api/start_chat",
@@ -317,8 +320,9 @@ class TestTopicDescriptions:
         topics = ["general", "weather", "hobby", "news", "food"]
 
         for topic in topics:
-            with patch("app.create_model_and_get_response") as mock_response:
-                mock_response.return_value = "テスト応答"
+            with patch("app.initialize_llm") as mock_llm, patch("app.extract_content") as mock_extract:
+                mock_llm.return_value.invoke.return_value = "テスト応答"
+                mock_extract.return_value = "テスト応答"
 
                 response = client.post(
                     "/api/start_chat",


### PR DESCRIPTION
## Summary
雑談開始時にシステムプロンプトがLLMに渡されず、Gemma 4 31B が「ポイント:」等のメタ解説を出力するバグを修正。

## 原因
\`create_model_and_get_response()\` で素テキストのみ送信しており、セッションに保存された「セリフのみ出力」制約が初回メッセージに適用されていなかった。

## 修正
- \`SystemMessage\` + \`HumanMessage\` で初回からシステムプロンプトを送信
- テストのモックを更新（1487 passed）

## Test plan
- [x] 全テスト 1487 passed
- [ ] 本番で雑談開始 → メタ解説なしの自然な会話

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cacc-lab/workplace-roleplay/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
